### PR TITLE
Change start vol from 75% to 25%

### DIFF
--- a/applications/music_player/music_player.c
+++ b/applications/music_player/music_player.c
@@ -251,7 +251,7 @@ MusicPlayer* music_player_alloc() {
     instance->model = malloc(sizeof(MusicPlayerModel));
     memset(instance->model->duration_history, 0xff, MUSIC_PLAYER_SEMITONE_HISTORY_SIZE);
     memset(instance->model->semitone_history, 0xff, MUSIC_PLAYER_SEMITONE_HISTORY_SIZE);
-    instance->model->volume = 3;
+    instance->model->volume = 1;
 
     instance->model_mutex = osMutexNew(NULL);
 


### PR DESCRIPTION
# What's new

- Changing the initial volume of music_player from 75% down to 25%

# Verification 

- Making the change myself confirms it works
- Started music_player and the volume was reduced

# Checklist (For Reviewer)

- [ X ] PR has a description of feature/bug or link to Confluence/Jira task
- [ X ] Description contains actions to verify feature/bugfix
- [ X ] I've built this code, uploaded it to the device, and verified the feature/bugfix
