### PR TITLE
Fixes bad usb subdirectory file errors

### DIFF
--- a/applications/bad_usb/bad_usb_app.c
+++ b/applications/bad_usb/bad_usb_app.c
@@ -42,13 +42,21 @@ static bool bad_usb_check_assets() {
 
 BadUsbApp* bad_usb_app_alloc(char* arg) {
     BadUsbApp* app = malloc(sizeof(BadUsbApp));
-
+    
     if(arg != NULL) {
-        string_t filename;
-        string_init(filename);
-        path_extract_filename_no_ext(arg, filename);
-        strncpy(app->file_name, string_get_cstr(filename), BAD_USB_FILE_NAME_LEN);
-        string_clear(filename);
+      string_t filename;
+      string_init(filename);
+
+      string_t subdirnames;
+      string_init(subdirnames);
+
+      path_extract_subdirnames(arg, subdirnames);
+      path_extract_filename_no_ext(arg, filename);
+      
+      snprintf(app->file_name, BAD_USB_FILE_NAME_LEN, "%s/%s", string_get_cstr(subdirnames), string_get_cstr(filename));
+      
+      string_clear(filename);
+      string_clear(subdirnames);
     }
 
     app->gui = furi_record_open("gui");

--- a/lib/toolbox/path.c
+++ b/lib/toolbox/path.c
@@ -44,6 +44,19 @@ void path_extract_dirname(const char* path, string_t dirname) {
     }
 }
 
+void path_extract_subdirnames(const char* path, string_t subdirnames) {
+    string_set(subdirnames, path);
+    path_cleanup(subdirnames);
+
+    for(int i = 0; i<3; i++) {
+      size_t pos_start = string_search_char(subdirnames, '/');
+      string_mid(subdirnames, pos_start + 1, string_size(subdirnames));
+    }
+
+    size_t pos_end = string_search_rchar(subdirnames, '/');
+    string_mid(subdirnames, 0, pos_end);
+}
+
 void path_append(string_t path, const char* suffix) {
     path_cleanup(path);
     string_t suffix_str;

--- a/lib/toolbox/path.h
+++ b/lib/toolbox/path.h
@@ -31,6 +31,14 @@ void path_extract_basename(const char* path, string_t basename);
 void path_extract_dirname(const char* path, string_t dirname);
 
 /**
+ * @brief Extract all sub directory names after initial root directory
+ *
+ * @param path path string
+ * @param subdirname output string. Must be initialized before.
+ */
+void path_extract_subdirnames(const char* path, string_t subdirnames);
+    
+/**
  * @brief Appends new component to path, adding path delimiter
  * 
  * @param path path string


### PR DESCRIPTION
# What's new

- Fixes bad usb sub directories causing file errors caused by incorrect parsing of path variable

# Verification 

- Create multi depth sub directory and place a bad usb script inside.
- Run bad usb script

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
