### PR TITLE
Fixing wav_player dialog

### DIFF
--- a/applications/wav_player/wav_player.c
+++ b/applications/wav_player/wav_player.c
@@ -26,11 +26,9 @@ static bool open_wav_stream(Storage* storage, Stream* stream) {
                 true,
                 &I_music_10px,
                 false);
-
     furi_record_close("dialogs");
-
+    
     if(ret) {
-        string_printf(path, "%s/%s.%s", "/ext/wav_player", name_buffer, "wav");
         if(!file_stream_open(stream, string_get_cstr(path), FSAM_READ, FSOM_OPEN_EXISTING)) {
             FURI_LOG_E(TAG, "Cannot open file \"%s\"", string_get_cstr(path));
         } else {


### PR DESCRIPTION
# What's new

- Fixing file dialog for wav_player

# Verification 

- Run wav_player, check if you begin in /ext/wav_player, choose file.

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [-] Description contains actions to verify feature/bugfix
- [-] I've built this code, uploaded it to the device and verified feature/bugfix
