### PR TITLE
Chip8 File Select Fix

### DIFF
--- a/applications/chip8/chip8.c
+++ b/applications/chip8/chip8.c
@@ -32,10 +32,10 @@ static int32_t chip8_worker(void* context) {
 
     FURI_LOG_I(WORKER_TAG, "Start storage file alloc");
     File* rom_file = storage_file_alloc(furi_storage_record);
-    FURI_LOG_I(WORKER_TAG, "Start storage file open, path = %s", chip8->file_path);
+    FURI_LOG_I(WORKER_TAG, "Start storage file open, path = %s", string_get_cstr(chip8->file_path));
 
-    uint8_t* rom_data = malloc(2048);
-    FURI_LOG_I(WORKER_TAG, "2048 array gotten");
+    uint8_t* rom_data = malloc(4096);
+    FURI_LOG_I(WORKER_TAG, "4096 array gotten");
 
 
     while(1) {
@@ -115,7 +115,7 @@ static int32_t chip8_worker(void* context) {
 
 Chip8Emulator* chip8_make_emulator(string_t file_path) {
     furi_assert(file_path);
-    FURI_LOG_I("CHIP8", "make emulator, file_path=", file_path);
+    FURI_LOG_I("CHIP8", "make emulator, file_path=", string_get_cstr(file_path));
 
     Chip8Emulator* chip8 = malloc(sizeof(Chip8Emulator));
     string_init(chip8->file_path);
@@ -138,7 +138,7 @@ Chip8Emulator* chip8_make_emulator(string_t file_path) {
 
     chip8->thread = furi_thread_alloc();
     furi_thread_set_name(chip8->thread, "Chip8Worker");
-    furi_thread_set_stack_size(chip8->thread, 2048);
+    furi_thread_set_stack_size(chip8->thread, 4096);
     furi_thread_set_context(chip8->thread, chip8);
     furi_thread_set_callback(chip8->thread, chip8_worker);
 

--- a/applications/chip8/chip8_app_i.h
+++ b/applications/chip8/chip8_app_i.h
@@ -15,7 +15,6 @@
 
 #define CHIP8_APP_PATH_FOLDER "/any/chip8"
 #define CHIP8_APP_EXTENSION ".ch8"
-#define CHIP8_FILE_NAME_LEN 40
 
 struct Chip8App{
     Gui* gui;
@@ -23,7 +22,7 @@ struct Chip8App{
     SceneManager* scene_manager;
     DialogsApp* dialogs;
 
-    char file_name[CHIP8_FILE_NAME_LEN+ 1];
+    string_t file_name;
     uint8_t** backup_screen;
     Chip8View* chip8_view;
     Chip8Emulator* chip8;

--- a/applications/chip8/scenes/chip8_scene_file_select.c
+++ b/applications/chip8/scenes/chip8_scene_file_select.c
@@ -3,19 +3,21 @@
 
 static bool chip8_file_select(Chip8App* chip8) {
     furi_assert(chip8);
-    string_t file_path;
-    string_init(file_path);
-    string_set_str(file_path, CHIP8_APP_PATH_FOLDER);
+    string_init(chip8->file_name);
+    string_set_str(chip8->file_name, CHIP8_APP_PATH_FOLDER);
     // string_set_str(file_path, chip8->file_name);
 
     bool res = dialog_file_browser_show(
         chip8->dialogs,
-        file_path,
-        file_path,
+        chip8->file_name,
+        chip8->file_name,
         CHIP8_APP_EXTENSION,
         true,
         &I_unknown_10px,
         false);
+
+	FURI_LOG_I("Chip8_file_browser_show", "chip8->file_name: %s", string_get_cstr(chip8->file_name));
+	FURI_LOG_I("Chip8_file_browser_show", "res: %d", res);
     return res;
 }
 
@@ -23,7 +25,7 @@ void chip8_scene_file_select_on_enter(void* context) {
     Chip8App* chip8 = context;
 
     if(chip8_file_select(chip8)) {
-        FURI_LOG_I("Chip8", "chip8_file_select, file_name = %s", chip8->file_name);
+        FURI_LOG_I("Chip8", "chip8_file_select, file_name = %s", string_get_cstr(chip8->file_name));
         scene_manager_next_scene(chip8->scene_manager, Chip8WorkView);
     } else {
         view_dispatcher_stop(chip8->view_dispatcher);
@@ -31,8 +33,11 @@ void chip8_scene_file_select_on_enter(void* context) {
 }
 
 bool chip8_scene_file_select_on_event(void* context, SceneManagerEvent event) {
+	UNUSED(context);
+	UNUSED(event);
     return false;
 }
 
 void chip8_scene_file_select_on_exit(void* context) {
+	UNUSED(context);
 }

--- a/applications/chip8/scenes/chip8_scene_work.c
+++ b/applications/chip8/scenes/chip8_scene_work.c
@@ -56,21 +56,22 @@ bool chip8_scene_work_on_event(void* context, SceneManagerEvent event) {
 void chip8_scene_work_on_enter(void* context) {
     Chip8App* app = context;
 
-    string_t file_name;
-    string_init(file_name);
-
     chip8_set_file_name(app->chip8_view, app->file_name);
 
-    string_printf(
-        file_name, "%s/%s%s", CHIP8_APP_PATH_FOLDER, app->file_name, CHIP8_APP_EXTENSION);
+	string_t file_tmp;
+	string_init(file_tmp);
+
+    string_printf(file_tmp, "%s", string_get_cstr(app->file_name));
+
+	FURI_LOG_I("chip8_scene_work_on_enter","file_name: %s", string_get_cstr(file_tmp));
 
     FURI_LOG_I("chip8_scene_work_on_enter", "START SET BACKUP SCREEN");
     chip8_set_backup_screen(app->chip8_view, app->backup_screen);
     FURI_LOG_I("chip8_scene_work_on_enter", "END SET BACKUP SCREEN");
 
-    app->chip8 = chip8_make_emulator(file_name);
+    app->chip8 = chip8_make_emulator(file_tmp);
 
-    string_clear(file_name);
+	string_clear(file_tmp);
 
     chip8_set_state(app->chip8_view, chip8_get_state(app->chip8));
 

--- a/applications/chip8/views/chip8_view.c
+++ b/applications/chip8/views/chip8_view.c
@@ -14,7 +14,7 @@ struct Chip8View {
 };
 
 typedef struct {
-    char* file_name;
+    string_t file_name;
     Chip8State state;
     uint8_t** backup_screen;
 } Chip8Model;
@@ -171,11 +171,11 @@ void chip8_set_down_callback(Chip8View* chip8, Chip8ViewKeyDownCallback callback
         });
 }
 
-void chip8_set_file_name(Chip8View* chip8, char* name) {
+void chip8_set_file_name(Chip8View* chip8, string_t name) {
     furi_assert(name);
     with_view_model(
         chip8->view, (Chip8Model* model) {
-            model->file_name = name;
+            *model->file_name = *name;
             return false;
         });
 }

--- a/applications/chip8/views/chip8_view.h
+++ b/applications/chip8/views/chip8_view.h
@@ -27,6 +27,6 @@ void chip8_set_release_callback(Chip8View* chip8, Chip8ViewReleaseCallback callb
 
 void chip8_set_backup_screen(Chip8View* chip8, uint8_t** screen);
 
-void chip8_set_file_name(Chip8View* chip8, char* name);
+void chip8_set_file_name(Chip8View* chip8, string_t name);
 
 void chip8_set_state(Chip8View* chip8, Chip8State* st);


### PR DESCRIPTION
Chip8 Emulator - File Select wasn't working due to not pushing the correct variables to the functions.

Emulation still needs work though.