### PR TITLE
Added support for .txt map filename for easier editing on mobile

### DIFF
--- a/applications/unirfremix/unirfremix_app.c
+++ b/applications/unirfremix/unirfremix_app.c
@@ -148,14 +148,15 @@ static char* extract_filename(const char* name, int len) {
 */
 
 void unirfremix_cfg_set_check(UniRFRemix* app) {
+    //set file name to universal_rf_map.txt first
     string_t file_name;
     string_init(file_name);
-    string_set(file_name, "/any/subghz/assets/universal_rf_map");
+    string_set(file_name, "/any/subghz/assets/universal_rf_map.txt");
 
     Storage* storage = furi_record_open("storage");
     FlipperFormat* fff_data_file = flipper_format_file_alloc(storage);
 
-    app->file_result = 0;
+    app->file_result = 3;
     app->file_blank = 0;
 
     app->up_enabled = 1;
@@ -165,20 +166,19 @@ void unirfremix_cfg_set_check(UniRFRemix* app) {
     app->ok_enabled = 1;
 
     int label_len = 12;
+    int legacy = 0;
 
     //check that map file exists
     if(!flipper_format_file_open_existing(fff_data_file, string_get_cstr(file_name))) {
         FURI_LOG_I(TAG, "Could not open MAP file %s", string_get_cstr(file_name));
-        app->file_result = 1;
-    }
-	else
-	{
-        //Filename Assignment/Check Start		
+        legacy = 1;
+    } else {
+        legacy = 0;
+        //Filename Assignment/Check Start
 
         //assign variables to values within map file
         //set missing filenames to N/A
-        if(!flipper_format_read_string(fff_data_file, "UP", app->up_file))
-		{
+        if(!flipper_format_read_string(fff_data_file, "UP", app->up_file)) {
             FURI_LOG_I(TAG, "Could not read UP string");
 
             //increment file_blank for processing later
@@ -191,19 +191,16 @@ void unirfremix_cfg_set_check(UniRFRemix* app) {
             app->up_enabled = 0;
 
             FURI_LOG_I(TAG, "Up_Enabled: %d", app->up_enabled);
-        }
-		else
-		{
-			//check name length for proper screen fit
-			//then set filename as label. Might be replaced with defined label later on below.
-			app->up_label = extract_filename(string_get_cstr(app->up_file), label_len);
+        } else {
+            //check name length for proper screen fit
+            //then set filename as label. Might be replaced with defined label later on below.
+            app->up_label = extract_filename(string_get_cstr(app->up_file), label_len);
 
-			FURI_LOG_I(TAG, "UP file: %s", string_get_cstr(app->up_file));
-		}	
+            FURI_LOG_I(TAG, "UP file: %s", string_get_cstr(app->up_file));
+        }
 
         //Repeat process for Down
-        if(!flipper_format_read_string(fff_data_file, "DOWN", app->down_file))
-		{
+        if(!flipper_format_read_string(fff_data_file, "DOWN", app->down_file)) {
             FURI_LOG_I(TAG, "Could not read DOWN string");
 
             app->file_blank++;
@@ -211,17 +208,14 @@ void unirfremix_cfg_set_check(UniRFRemix* app) {
             app->down_enabled = 0;
 
             FURI_LOG_I(TAG, "Down_Enabled: %d", app->down_enabled);
-        }
-		else
-		{
+        } else {
             app->down_label = extract_filename(string_get_cstr(app->down_file), label_len);
 
             FURI_LOG_I(TAG, "DOWN file: %s", string_get_cstr(app->down_file));
         }
 
         //Repeat process for Left
-        if(!flipper_format_read_string(fff_data_file, "LEFT", app->left_file))
-		{
+        if(!flipper_format_read_string(fff_data_file, "LEFT", app->left_file)) {
             FURI_LOG_I(TAG, "Could not read LEFT string");
 
             app->file_blank++;
@@ -229,17 +223,14 @@ void unirfremix_cfg_set_check(UniRFRemix* app) {
             app->left_enabled = 0;
 
             FURI_LOG_I(TAG, "Left_Enabled: %d", app->left_enabled);
-        }
-		else
-		{
+        } else {
             app->left_label = extract_filename(string_get_cstr(app->left_file), label_len);
 
             FURI_LOG_I(TAG, "LEFT file: %s", string_get_cstr(app->left_file));
         }
 
         //Repeat process for Right
-        if(!flipper_format_read_string(fff_data_file, "RIGHT", app->right_file))
-		{
+        if(!flipper_format_read_string(fff_data_file, "RIGHT", app->right_file)) {
             FURI_LOG_I(TAG, "Could not read RIGHT string");
 
             app->file_blank++;
@@ -247,17 +238,14 @@ void unirfremix_cfg_set_check(UniRFRemix* app) {
             app->right_enabled = 0;
 
             FURI_LOG_I(TAG, "Right_Enabled: %d", app->right_enabled);
-        }
-		else
-		{
+        } else {
             app->right_label = extract_filename(string_get_cstr(app->right_file), label_len);
 
             FURI_LOG_I(TAG, "RIGHT file: %s", string_get_cstr(app->right_file));
         }
 
         //Repeat process for Ok
-        if(!flipper_format_read_string(fff_data_file, "OK", app->ok_file))
-		{
+        if(!flipper_format_read_string(fff_data_file, "OK", app->ok_file)) {
             FURI_LOG_I(TAG, "Could not read OK string");
 
             app->file_blank++;
@@ -265,16 +253,11 @@ void unirfremix_cfg_set_check(UniRFRemix* app) {
             app->ok_enabled = 0;
 
             FURI_LOG_I(TAG, "Ok_Enabled: %d", app->ok_enabled);
-        }
-		else
-		{
+        } else {
             app->ok_label = extract_filename(string_get_cstr(app->ok_file), label_len);
 
             FURI_LOG_I(TAG, "OK file: %s", string_get_cstr(app->ok_file));
         }
-		
-		//File definitions are done.
-		//File checks will follow after label assignment in order to close the universal_rf_map file without the need to reopen it again.
 
         //File definitions are done.
         //File checks will follow after label assignment in order to close the universal_rf_map file without the need to reopen it again.
@@ -364,137 +347,317 @@ void unirfremix_cfg_set_check(UniRFRemix* app) {
 
             FURI_LOG_I(TAG, "OK label: %s", app->ok_label);
         }
+
+        app->file_result = 4;
     }
 
-	//Close universal_rf_map
     flipper_format_free(fff_data_file);
     furi_record_close("storage");
-	
-	//File Existence Check
-	//Check each file definition if not already set to "N/A"
-	
-	//determine if files exist.
-	//determine whether or not to continue to launch app with missing variables
-	//if 5 files are missing, throw error
 
-    if(app->file_blank == 5)
-	{
-		//trigger invalid file error screen
-		app->file_result = 2;
-	}
-	else
-	{
-		//check all files
-		//reset app->file_blank to redetermine if error needs to be thrown
-		app->file_blank = 0;
-		
-		//if button is still enabled, check that file exists
-		if(app->up_enabled == 1)
-		{
-			string_set(file_name, app->up_file);
-			Storage* storage = furi_record_open("storage");
-			FlipperFormat* fff_data_file = flipper_format_file_alloc(storage);
-			
-			if(!flipper_format_file_open_existing(fff_data_file, string_get_cstr(file_name)))
-			{
-				FURI_LOG_I(TAG, "Could not open UP file %s", string_get_cstr(file_name));
-				
-				//disable button, and set label to "N/A"
-				app->up_enabled = 0;
-				app->up_label = "N/A";
-				app->file_blank++;
-			}
-			
-			//close the file
-			flipper_format_free(fff_data_file);
-			furi_record_close("storage");
-		}
-		
-		if(app->down_enabled == 1)
-		{
-			string_set(file_name, app->down_file);
-			Storage* storage = furi_record_open("storage");
-			FlipperFormat* fff_data_file = flipper_format_file_alloc(storage);
-			
-			if(!flipper_format_file_open_existing(fff_data_file, string_get_cstr(file_name)))
-			{
-				FURI_LOG_I(TAG, "Could not open DOWN file %s", string_get_cstr(file_name));
-				
-				app->down_enabled = 0;
-				app->down_label = "N/A";
-				app->file_blank++;
-			}
-			
-			flipper_format_free(fff_data_file);
-			furi_record_close("storage");
-		}
-		
-		if(app->left_enabled == 1)
-		{
-			string_set(file_name, app->left_file);
-			Storage* storage = furi_record_open("storage");
-			FlipperFormat* fff_data_file = flipper_format_file_alloc(storage);
-			
-			if(!flipper_format_file_open_existing(fff_data_file, string_get_cstr(file_name)))
-			{
-				FURI_LOG_I(TAG, "Could not open LEFT file %s", string_get_cstr(file_name));
-				
-				app->left_enabled = 0;
-				app->left_label = "N/A";
-				app->file_blank++;
-			}
-			
-			flipper_format_free(fff_data_file);
-			furi_record_close("storage");
-		}
-		
-		if(app->right_enabled == 1)
-		{
-			string_set(file_name, app->right_file);
-			Storage* storage = furi_record_open("storage");
-			FlipperFormat* fff_data_file = flipper_format_file_alloc(storage);
-			
-			if(!flipper_format_file_open_existing(fff_data_file, string_get_cstr(file_name)))
-			{
-				FURI_LOG_I(TAG, "Could not open RIGHT file %s", string_get_cstr(file_name));
-				
-				app->right_enabled = 0;
-				app->right_label = "N/A";
-				app->file_blank++;
-			}
-			
-			flipper_format_free(fff_data_file);
-			furi_record_close("storage");
-		}
-		
-		if(app->ok_enabled == 1)
-		{
-			string_set(file_name, app->ok_file);
-			Storage* storage = furi_record_open("storage");
-			FlipperFormat* fff_data_file = flipper_format_file_alloc(storage);
-			
-			if(!flipper_format_file_open_existing(fff_data_file, string_get_cstr(file_name)))
-			{
-				FURI_LOG_I(TAG, "Could not open OK file %s", string_get_cstr(file_name));
-				
-				app->ok_enabled = 0;
-				app->ok_label = "N/A";
-				app->file_blank++;
-			}
-			
-			flipper_format_free(fff_data_file);
-			furi_record_close("storage");
-		}
-		
-		if(app->file_blank == 5)
-		{
-			app->file_result = 2;
-		}
-		else
-		{
-			app->file_result = 0;
-		}
-	}
+    if(legacy == 1) {
+        //check if legacy map exists (universal_rf_map)
+        string_set(file_name, "/any/subghz/assets/universal_rf_map");
+
+        storage = furi_record_open("storage");
+        fff_data_file = flipper_format_file_alloc(storage);
+
+        if(!flipper_format_file_open_existing(fff_data_file, string_get_cstr(file_name))) {
+            FURI_LOG_I(TAG, "Could not open legacy MAP file %s", string_get_cstr(file_name));
+            app->file_result = 1;
+        } else {
+            //Filename Assignment/Check Start
+
+            //assign variables to values within map file
+            //set missing filenames to N/A
+            if(!flipper_format_read_string(fff_data_file, "UP", app->up_file)) {
+                FURI_LOG_I(TAG, "Could not read UP string");
+
+                //increment file_blank for processing later
+                app->file_blank++;
+
+                //set label to "N/A"
+                app->up_label = "N/A";
+
+                //disable the ability to process the signal on button press
+                app->up_enabled = 0;
+
+                FURI_LOG_I(TAG, "Up_Enabled: %d", app->up_enabled);
+            } else {
+                //check name length for proper screen fit
+                //then set filename as label. Might be replaced with defined label later on below.
+                app->up_label = extract_filename(string_get_cstr(app->up_file), label_len);
+
+                FURI_LOG_I(TAG, "UP file: %s", string_get_cstr(app->up_file));
+            }
+
+            //Repeat process for Down
+            if(!flipper_format_read_string(fff_data_file, "DOWN", app->down_file)) {
+                FURI_LOG_I(TAG, "Could not read DOWN string");
+
+                app->file_blank++;
+                app->down_label = "N/A";
+                app->down_enabled = 0;
+
+                FURI_LOG_I(TAG, "Down_Enabled: %d", app->down_enabled);
+            } else {
+                app->down_label = extract_filename(string_get_cstr(app->down_file), label_len);
+
+                FURI_LOG_I(TAG, "DOWN file: %s", string_get_cstr(app->down_file));
+            }
+
+            //Repeat process for Left
+            if(!flipper_format_read_string(fff_data_file, "LEFT", app->left_file)) {
+                FURI_LOG_I(TAG, "Could not read LEFT string");
+
+                app->file_blank++;
+                app->left_label = "N/A";
+                app->left_enabled = 0;
+
+                FURI_LOG_I(TAG, "Left_Enabled: %d", app->left_enabled);
+            } else {
+                app->left_label = extract_filename(string_get_cstr(app->left_file), label_len);
+
+                FURI_LOG_I(TAG, "LEFT file: %s", string_get_cstr(app->left_file));
+            }
+
+            //Repeat process for Right
+            if(!flipper_format_read_string(fff_data_file, "RIGHT", app->right_file)) {
+                FURI_LOG_I(TAG, "Could not read RIGHT string");
+
+                app->file_blank++;
+                app->right_label = "N/A";
+                app->right_enabled = 0;
+
+                FURI_LOG_I(TAG, "Right_Enabled: %d", app->right_enabled);
+            } else {
+                app->right_label = extract_filename(string_get_cstr(app->right_file), label_len);
+
+                FURI_LOG_I(TAG, "RIGHT file: %s", string_get_cstr(app->right_file));
+            }
+
+            //Repeat process for Ok
+            if(!flipper_format_read_string(fff_data_file, "OK", app->ok_file)) {
+                FURI_LOG_I(TAG, "Could not read OK string");
+
+                app->file_blank++;
+                app->ok_label = "N/A";
+                app->ok_enabled = 0;
+
+                FURI_LOG_I(TAG, "Ok_Enabled: %d", app->ok_enabled);
+            } else {
+                app->ok_label = extract_filename(string_get_cstr(app->ok_file), label_len);
+
+                FURI_LOG_I(TAG, "OK file: %s", string_get_cstr(app->ok_file));
+            }
+
+            //File definitions are done.
+            //File checks will follow after label assignment in order to close the universal_rf_map file without the need to reopen it again.
+
+            //Label Assignment/Check Start
+
+            //assign variables to values within map file
+            if(!flipper_format_read_string(fff_data_file, "ULABEL", app->up_l)) {
+                FURI_LOG_I(TAG, "Could not read ULABEL string");
+
+                //if Up button is disabled, set the label to "N/A";
+                if(app->up_enabled == 0) {
+                    app->up_label = "N/A";
+                }
+            } else {
+                //check if button is disabled, and set label to "N/A" from missing map definition above
+                if(app->up_enabled == 0) {
+                    app->up_label = "N/A";
+                } else {
+                    //set label from map to variable and shrink to fit screen
+                    app->up_label = char_to_str((char*)string_get_cstr(app->up_l), label_len);
+                }
+
+                FURI_LOG_I(TAG, "UP label: %s", app->up_label);
+            }
+
+            if(!flipper_format_read_string(fff_data_file, "DLABEL", app->down_l)) {
+                FURI_LOG_I(TAG, "Could not read DLABEL string");
+
+                if(app->down_enabled == 0) {
+                    app->down_label = "N/A";
+                }
+            } else {
+                if(app->down_enabled == 0) {
+                    app->down_label = "N/A";
+                } else {
+                    app->down_label = char_to_str((char*)string_get_cstr(app->down_l), label_len);
+                }
+
+                FURI_LOG_I(TAG, "DOWN label: %s", app->down_label);
+            }
+
+            if(!flipper_format_read_string(fff_data_file, "LLABEL", app->left_l)) {
+                FURI_LOG_I(TAG, "Could not read LLABEL string");
+
+                if(app->left_enabled == 0) {
+                    app->left_label = "N/A";
+                }
+            } else {
+                if(app->left_enabled == 0) {
+                    app->left_label = "N/A";
+                } else {
+                    app->left_label = char_to_str((char*)string_get_cstr(app->left_l), label_len);
+                }
+
+                FURI_LOG_I(TAG, "LEFT label: %s", app->left_label);
+            }
+
+            if(!flipper_format_read_string(fff_data_file, "RLABEL", app->right_l)) {
+                FURI_LOG_I(TAG, "Could not read RLABEL string");
+
+                if(app->right_enabled == 0) {
+                    app->right_label = "N/A";
+                }
+            } else {
+                if(app->right_enabled == 0) {
+                    app->right_label = "N/A";
+                } else {
+                    app->right_label =
+                        char_to_str((char*)string_get_cstr(app->right_l), label_len);
+                }
+
+                FURI_LOG_I(TAG, "RIGHT label: %s", app->right_label);
+            }
+
+            if(!flipper_format_read_string(fff_data_file, "OKLABEL", app->ok_l)) {
+                FURI_LOG_I(TAG, "Could not read OKLABEL string");
+
+                if(app->ok_enabled == 0) {
+                    app->ok_label = "N/A";
+                }
+            } else {
+                if(app->ok_enabled == 0) {
+                    app->ok_label = "N/A";
+                } else {
+                    app->ok_label = char_to_str((char*)string_get_cstr(app->ok_l), label_len);
+                }
+
+                FURI_LOG_I(TAG, "OK label: %s", app->ok_label);
+            }
+
+            app->file_result = 4;
+        }
+
+        flipper_format_free(fff_data_file);
+        furi_record_close("storage");
+    }
+
+    //File Existence Check
+    //Check each file definition if not already set to "N/A"
+
+    //determine if files exist.
+    //determine whether or not to continue to launch app with missing variables
+    //if 5 files are missing, throw error
+
+    FURI_LOG_I(TAG, "app->file_blank: %d", app->file_blank);
+
+    if(app->file_blank == 5) {
+        //trigger invalid file error screen
+        app->file_result = 2;
+    } else {
+        //check all files
+        //reset app->file_blank to redetermine if error needs to be thrown
+        app->file_blank = 0;
+
+        //if button is still enabled, check that file exists
+        if(app->up_enabled == 1) {
+            string_set(file_name, app->up_file);
+            storage = furi_record_open("storage");
+            fff_data_file = flipper_format_file_alloc(storage);
+
+            if(!flipper_format_file_open_existing(fff_data_file, string_get_cstr(file_name))) {
+                FURI_LOG_I(TAG, "Could not open UP file %s", string_get_cstr(file_name));
+
+                //disable button, and set label to "N/A"
+                app->up_enabled = 0;
+                app->up_label = "N/A";
+                app->file_blank++;
+            }
+
+            //close the file
+            flipper_format_free(fff_data_file);
+            furi_record_close("storage");
+        }
+
+        if(app->down_enabled == 1) {
+            string_set(file_name, app->down_file);
+            storage = furi_record_open("storage");
+            fff_data_file = flipper_format_file_alloc(storage);
+
+            if(!flipper_format_file_open_existing(fff_data_file, string_get_cstr(file_name))) {
+                FURI_LOG_I(TAG, "Could not open DOWN file %s", string_get_cstr(file_name));
+
+                app->down_enabled = 0;
+                app->down_label = "N/A";
+                app->file_blank++;
+            }
+
+            flipper_format_free(fff_data_file);
+            furi_record_close("storage");
+        }
+
+        if(app->left_enabled == 1) {
+            string_set(file_name, app->left_file);
+            storage = furi_record_open("storage");
+            fff_data_file = flipper_format_file_alloc(storage);
+
+            if(!flipper_format_file_open_existing(fff_data_file, string_get_cstr(file_name))) {
+                FURI_LOG_I(TAG, "Could not open LEFT file %s", string_get_cstr(file_name));
+
+                app->left_enabled = 0;
+                app->left_label = "N/A";
+                app->file_blank++;
+            }
+
+            flipper_format_free(fff_data_file);
+            furi_record_close("storage");
+        }
+
+        if(app->right_enabled == 1) {
+            string_set(file_name, app->right_file);
+            storage = furi_record_open("storage");
+            fff_data_file = flipper_format_file_alloc(storage);
+
+            if(!flipper_format_file_open_existing(fff_data_file, string_get_cstr(file_name))) {
+                FURI_LOG_I(TAG, "Could not open RIGHT file %s", string_get_cstr(file_name));
+
+                app->right_enabled = 0;
+                app->right_label = "N/A";
+                app->file_blank++;
+            }
+
+            flipper_format_free(fff_data_file);
+            furi_record_close("storage");
+        }
+
+        if(app->ok_enabled == 1) {
+            string_set(file_name, app->ok_file);
+            storage = furi_record_open("storage");
+            fff_data_file = flipper_format_file_alloc(storage);
+
+            if(!flipper_format_file_open_existing(fff_data_file, string_get_cstr(file_name))) {
+                FURI_LOG_I(TAG, "Could not open OK file %s", string_get_cstr(file_name));
+
+                app->ok_enabled = 0;
+                app->ok_label = "N/A";
+                app->file_blank++;
+            }
+
+            flipper_format_free(fff_data_file);
+            furi_record_close("storage");
+        }
+
+        if(app->file_blank == 5) {
+            app->file_result = 2;
+        } else {
+            app->file_result = 4;
+        }
+    }
 }
 
 static void unirfremix_end_send(UniRFRemix* app) {
@@ -599,6 +762,8 @@ static void unirfremix_process_signal(UniRFRemix* app, string_t signal) {
 
         FURI_LOG_I(TAG, "%lu", frequency_str);
 
+        string_clear(file_name);
+
         unirfremix_send_signal(app, frequency_str, signal, protocol);
     } else if(strlen(string_get_cstr(signal)) < 10) {
         unirfremix_end_send(app);
@@ -628,6 +793,13 @@ static void render_callback(Canvas* canvas, void* ctx) {
         canvas_draw_str_aligned(canvas, 62, 25, AlignCenter, AlignTop, "Please configure");
         canvas_draw_str_aligned(canvas, 62, 35, AlignCenter, AlignTop, "universal_rf_map");
         canvas_draw_str_aligned(canvas, 62, 60, AlignCenter, AlignBottom, "Hold Back to Exit.");
+    } else if(app->file_result == 3) {
+        //if map has no valid filenames defined
+        canvas_clear(canvas);
+        canvas_set_font(canvas, FontPrimary);
+        canvas_draw_str_aligned(canvas, 62, 5, AlignCenter, AlignTop, "Config is loading.");
+        canvas_set_font(canvas, FontSecondary);
+        canvas_draw_str_aligned(canvas, 62, 35, AlignCenter, AlignTop, "Please wait.");
     } else {
         //map found, draw all the things
         canvas_clear(canvas);
@@ -643,12 +815,12 @@ static void render_callback(Canvas* canvas, void* ctx) {
 
         //Icons for Labels
         //canvas_draw_icon(canvas, 0, 0, &I_UniRFRemix_LeftAlignedButtons_9x64);
-		canvas_draw_icon(canvas, 1, 5, &I_ButtonUp_7x4);
-		canvas_draw_icon(canvas, 1, 15, &I_ButtonDown_7x4);
-		canvas_draw_icon(canvas, 2, 23, &I_ButtonLeft_4x7);
-		canvas_draw_icon(canvas, 2, 33, &I_ButtonRight_4x7);
-		canvas_draw_icon(canvas, 0, 42, &I_Ok_btn_9x9);
-		canvas_draw_icon(canvas, 0, 53, &I_back_10px);
+        canvas_draw_icon(canvas, 1, 5, &I_ButtonUp_7x4);
+        canvas_draw_icon(canvas, 1, 15, &I_ButtonDown_7x4);
+        canvas_draw_icon(canvas, 2, 23, &I_ButtonLeft_4x7);
+        canvas_draw_icon(canvas, 2, 33, &I_ButtonRight_4x7);
+        canvas_draw_icon(canvas, 0, 42, &I_Ok_btn_9x9);
+        canvas_draw_icon(canvas, 0, 53, &I_back_10px);
 
         //Labels
         canvas_set_font(canvas, FontSecondary);
@@ -658,7 +830,8 @@ static void render_callback(Canvas* canvas, void* ctx) {
         canvas_draw_str(canvas, 10, 40, app->right_label);
         canvas_draw_str(canvas, 10, 50, app->ok_label);
 
-        canvas_draw_str_aligned(canvas, 11, 62, AlignLeft, AlignBottom, "Hold=Exit. Tap for Repeat:");
+        canvas_draw_str_aligned(
+            canvas, 11, 62, AlignLeft, AlignBottom, "Hold=Exit. Tap for Repeat:");
 
         //Status text and indicator
         canvas_draw_str_aligned(canvas, 126, 10, AlignRight, AlignBottom, app->send_status);
@@ -724,6 +897,19 @@ UniRFRemix* unirfremix_alloc() {
 }
 
 void unirfremix_free(UniRFRemix* app) {
+    string_clear(app->up_file);
+    string_clear(app->down_file);
+    string_clear(app->left_file);
+    string_clear(app->right_file);
+    string_clear(app->ok_file);
+    string_clear(app->empty);
+
+    string_clear(app->up_l);
+    string_clear(app->down_l);
+    string_clear(app->left_l);
+    string_clear(app->right_l);
+    string_clear(app->ok_l);
+
     gui_remove_view_port(app->gui, app->view_port);
     furi_record_close("gui");
     view_port_free(app->view_port);
@@ -753,12 +939,14 @@ int32_t unirfremix_app(void* p) {
     string_init(app->right_l);
     string_init(app->ok_l);
 
+    app->file_result = 3;
+
     //check map and population variables
     unirfremix_cfg_set_check(app);
 
     bool exit_loop = false;
 
-    if(app->file_result == 0) {
+    if(app->file_result == 4) {
         FURI_LOG_I(
             TAG,
             "U: %s - D: %s - L: %s - R: %s - O: %s ",


### PR DESCRIPTION
The ability to read the file map from universal_rf_map.txt filename for the SubGhz Remote Remix app was requested. This was for easier editing on mobile devices.

Backwards compatibility for original universal_rf_map filename was kept

Added a screen in case of slow loading