### PR TITLE
Add a back button function to raycast_game.c

### DIFF
--- a/applications/raycast_game/raycast_game.c
+++ b/applications/raycast_game/raycast_game.c
@@ -428,6 +428,11 @@ int32_t raycast_game_app(void* p) {
                 if(button_state & (1 << InputKeyUp) || button_state & (1 << InputKeyDown)) {
                     move_player(player, button_state & (1 << InputKeyUp));
                 }
+				
+				if(button_state & (1 << InputKeyBack)) {
+					processing = false;
+				}
+				
                 return true;
             });
     }


### PR DESCRIPTION
You can now press the back button to leave the raycast game.

# What's new

- You can now press the back button to quit the raycast game.

# Verification 

- Press the back button while playing the raycast game to test escaping it.

# Checklist (For Reviewer)

- [ X ] PR has description of feature/bug or link to Confluence/Jira task
- [ X ] Description contains actions to verify feature/bugfix
- [ X ] I've built this code, uploaded it to the device and verified feature/bugfix
