### PR TITLE
Favorite Games Menu by holding Up on Desktop and simple fix to Tic Tac Toe

### DIFF
--- a/applications/desktop/desktop_settings/desktop_settings.h
+++ b/applications/desktop/desktop_settings/desktop_settings.h
@@ -39,6 +39,7 @@ typedef struct {
 typedef struct {
     uint16_t favorite_primary;
     uint16_t favorite_secondary;
+    uint16_t favorite_game;
     PinCode pin_code;
     uint8_t is_locked;
     uint32_t auto_lock_delay_ms;

--- a/applications/desktop/desktop_settings/scenes/desktop_settings_scene_favorite.c
+++ b/applications/desktop/desktop_settings/scenes/desktop_settings_scene_favorite.c
@@ -7,11 +7,7 @@ static void desktop_settings_scene_favorite_submenu_callback(void* context, uint
     view_dispatcher_send_custom_event(app->view_dispatcher, index);
 }
 
-void desktop_settings_scene_favorite_on_enter(void* context) {
-    DesktopSettingsApp* app = context;
-    Submenu* submenu = app->submenu;
-    submenu_reset(submenu);
-
+void add_favorite_submenu_item(DesktopSettingsApp* app, Submenu* submenu) {
     for(size_t i = 0; i < FLIPPER_APPS_COUNT; i++) {
         submenu_add_item(
             submenu,
@@ -20,18 +16,47 @@ void desktop_settings_scene_favorite_on_enter(void* context) {
             desktop_settings_scene_favorite_submenu_callback,
             app);
     }
+}
 
-    uint32_t primary_favorite =
+void add_game_submenu_item(DesktopSettingsApp* app, Submenu* submenu) {
+    for(size_t i = 0; i < FLIPPER_GAMES_COUNT; i++) {
+        submenu_add_item(
+            submenu,
+            FLIPPER_GAMES[i].name,
+            i,
+            desktop_settings_scene_favorite_submenu_callback,
+            app);
+    }
+}
+
+void desktop_settings_scene_favorite_on_enter(void* context) {
+    DesktopSettingsApp* app = context;
+    Submenu* submenu = app->submenu;
+    submenu_reset(submenu);
+
+    uint32_t favorite =
         scene_manager_get_scene_state(app->scene_manager, DesktopSettingsAppSceneFavorite);
 
-    submenu_set_header(
-        app->submenu, primary_favorite ? "Primary favorite app:" : "Secondary favorite app:");
-
-    if(primary_favorite) {
+    switch(favorite) {
+    case 0:
+        add_favorite_submenu_item(app, submenu);
+        submenu_set_header(app->submenu, "Primary favorite app:");
         submenu_set_selected_item(app->submenu, app->settings.favorite_primary);
-    } else {
+        break;
+    case 1:
+        add_favorite_submenu_item(app, submenu);
+        submenu_set_header(app->submenu, "Secondary favorite app:");
         submenu_set_selected_item(app->submenu, app->settings.favorite_secondary);
+        break;
+    case 2:
+        add_game_submenu_item(app, submenu);
+        submenu_set_header(app->submenu, "Favorite game:");
+        submenu_set_selected_item(app->submenu, app->settings.favorite_game);
+        break;
+    default:
+        break;
     }
+
     view_dispatcher_switch_to_view(app->view_dispatcher, DesktopSettingsAppViewMenu);
 }
 
@@ -39,18 +64,27 @@ bool desktop_settings_scene_favorite_on_event(void* context, SceneManagerEvent e
     DesktopSettingsApp* app = context;
     bool consumed = false;
 
-    uint32_t primary_favorite =
+    uint32_t favorite =
         scene_manager_get_scene_state(app->scene_manager, DesktopSettingsAppSceneFavorite);
 
     if(event.type == SceneManagerEventTypeCustom) {
-        if(primary_favorite) {
+        switch(favorite) {
+        case 0:
             app->settings.favorite_primary = event.event;
-        } else {
+            break;
+        case 1:
             app->settings.favorite_secondary = event.event;
+            break;
+        case 2:
+            app->settings.favorite_game = event.event;
+            break;
+        default:
+            break;
         }
-        scene_manager_previous_scene(app->scene_manager);
-        consumed = true;
     }
+
+    scene_manager_previous_scene(app->scene_manager);
+    consumed = true;
     return consumed;
 }
 

--- a/applications/desktop/desktop_settings/scenes/desktop_settings_scene_start.c
+++ b/applications/desktop/desktop_settings/scenes/desktop_settings_scene_start.c
@@ -6,8 +6,9 @@
 
 #define SCENE_EVENT_SELECT_FAVORITE_PRIMARY 0
 #define SCENE_EVENT_SELECT_FAVORITE_SECONDARY 1
-#define SCENE_EVENT_SELECT_PIN_SETUP 2
-#define SCENE_EVENT_SELECT_AUTO_LOCK_DELAY 3
+#define SCENE_EVENT_SELECT_FAVORITE_GAME 2
+#define SCENE_EVENT_SELECT_PIN_SETUP 3
+#define SCENE_EVENT_SELECT_AUTO_LOCK_DELAY 4
 
 #define AUTO_LOCK_DELAY_COUNT 6
 const char* const auto_lock_delay_text[AUTO_LOCK_DELAY_COUNT] = {
@@ -46,6 +47,8 @@ void desktop_settings_scene_start_on_enter(void* context) {
 
     variable_item_list_add(variable_item_list, "Secondary Favorite App", 1, NULL, NULL);
 
+    variable_item_list_add(variable_item_list, "Favorite Game", 1, NULL, NULL);
+
     variable_item_list_add(variable_item_list, "PIN Setup", 1, NULL, NULL);
 
     item = variable_item_list_add(
@@ -65,19 +68,24 @@ void desktop_settings_scene_start_on_enter(void* context) {
     view_dispatcher_switch_to_view(app->view_dispatcher, DesktopSettingsAppViewVarItemList);
 }
 
-bool desktop_settings_scene_start_on_event(void* context, SceneManagerEvent event) {
+bool desktop_settings_scene_start_on_event(void* context, SceneManagerEvent sme) {
     DesktopSettingsApp* app = context;
     bool consumed = false;
 
-    if(event.type == SceneManagerEventTypeCustom) {
-        switch(event.event) {
+    if(sme.type == SceneManagerEventTypeCustom) {
+        switch(sme.event) {
         case SCENE_EVENT_SELECT_FAVORITE_PRIMARY:
-            scene_manager_set_scene_state(app->scene_manager, DesktopSettingsAppSceneFavorite, 1);
+            scene_manager_set_scene_state(app->scene_manager, DesktopSettingsAppSceneFavorite, 0);
             scene_manager_next_scene(app->scene_manager, DesktopSettingsAppSceneFavorite);
             consumed = true;
             break;
         case SCENE_EVENT_SELECT_FAVORITE_SECONDARY:
-            scene_manager_set_scene_state(app->scene_manager, DesktopSettingsAppSceneFavorite, 0);
+            scene_manager_set_scene_state(app->scene_manager, DesktopSettingsAppSceneFavorite, 1);
+            scene_manager_next_scene(app->scene_manager, DesktopSettingsAppSceneFavorite);
+            consumed = true;
+            break;
+        case SCENE_EVENT_SELECT_FAVORITE_GAME:
+            scene_manager_set_scene_state(app->scene_manager, DesktopSettingsAppSceneFavorite, 2);
             scene_manager_next_scene(app->scene_manager, DesktopSettingsAppSceneFavorite);
             consumed = true;
             break;

--- a/applications/desktop/scenes/desktop_scene_main.c
+++ b/applications/desktop/scenes/desktop_scene_main.c
@@ -140,6 +140,19 @@ bool desktop_scene_main_on_event(void* context, SceneManagerEvent event) {
             }
             consumed = true;
             break;
+        case DesktopMainEventOpenFavoriteGame:
+            LOAD_DESKTOP_SETTINGS(&desktop->settings);
+            if(desktop->settings.favorite_game < FLIPPER_GAMES_COUNT) {
+                LoaderStatus status = loader_start(
+                    desktop->loader, FLIPPER_GAMES[desktop->settings.favorite_game].name, NULL);
+                if(status != LoaderStatusOk) {
+                    FURI_LOG_E(TAG, "loader_start failed: %d", status);
+                }
+            } else {
+                FURI_LOG_E(TAG, "Can't find game favorite application");
+            }
+            consumed = true;
+            break;
         case DesktopAnimationEventCheckAnimation:
             animation_manager_check_blocking_process(desktop->animation_manager);
             consumed = true;

--- a/applications/desktop/views/desktop_events.h
+++ b/applications/desktop/views/desktop_events.h
@@ -5,6 +5,7 @@ typedef enum {
     DesktopMainEventOpenArchive,
     DesktopMainEventOpenFavoritePrimary,
     DesktopMainEventOpenFavoriteSecondary,
+    DesktopMainEventOpenFavoriteGame,
     DesktopMainEventOpenMenu,
     DesktopMainEventOpenDebug,
     DesktopMainEventOpenPassport, /**< Broken, don't use it */

--- a/applications/desktop/views/desktop_view_main.c
+++ b/applications/desktop/views/desktop_view_main.c
@@ -61,6 +61,8 @@ bool desktop_main_input(InputEvent* event, void* context) {
             main_view->callback(DesktopMainEventOpenDebug, main_view->context);
         } else if(event->key == InputKeyLeft) {
             main_view->callback(DesktopMainEventOpenFavoriteSecondary, main_view->context);
+        } else if(event->key == InputKeyUp) {
+            main_view->callback(DesktopMainEventOpenFavoriteGame, main_view->context);
         }
     }
 

--- a/applications/tictactoe_game/tictactoe_game.c
+++ b/applications/tictactoe_game/tictactoe_game.c
@@ -149,37 +149,17 @@ void draw_win(Canvas* canvas, char player) {
         scoreO++;
     }
 
-    player_switch(); // Switches the players
+    // Switches the players
+    player_switch();
 
-    tictactoe_draw(canvas); // Draws the board with players switched
-
-    osDelay(
-        2000); // Delay for players to check which 3 squares led to the win - winning squares highlighting can be added
-
-    // Draws the win screen
-    int x = 54;
-    int y = 11;
-    canvas_set_font(canvas, FontPrimary);
-
-    if(player == 'X') {
-        canvas_draw_line(canvas, x, y, x + 20, y + 20); // top left - bottom right slash
-        canvas_draw_line(canvas, x + 20, y, x, y + 20); // down left - top right slash
-        canvas_draw_str(canvas, 48, 54, "Won!");
-    } else if(player == 'O') {
-        canvas_draw_circle(canvas, x + 10, y + 12, 12);
-        canvas_draw_str(canvas, 48, 54, "Won!");
-    } else if(player == 'T') {
-        canvas_set_font(canvas, FontSecondary);
-        canvas_draw_str(canvas, 42, 41, "TIE");
-    }
+    // Draws the board with players switched
+    tictactoe_draw(canvas);
 
     // Clear the game field
     clear_game_field();
 
-    osDelay(1500); // Show the above for 1500ms
-    tictactoe_draw(canvas); // Draw the new board
-    osDelay(
-        500); // Wait for 500ms to avoid accidental input (player pressing down the button while and after the win screen is showing)
+    // Draw the new board
+    tictactoe_draw(canvas);
 }
 
 static void tictactoe_state_init(TicTacToeState* const tictactoe_state) {


### PR DESCRIPTION
# What's new

Added a new **Favorite Game** menu item alongside **Primary Favorite App** and **Secondary Favorite App** under `Settings > Desktop`.

NOTE: Includes a minor fix to _Tic Tac Toe_ to remove delay when winning a game.

# Verification 

- Once a **Favorite Game** is selected it can be opened by holding **UP** on the **Desktop**.
- Win a game in Tic Tac Toe and there's no longer a delay.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix

# Video Demo:
https://discord.com/channels/740930220399525928/954430078882816021/986995428916596797