### PR TITLE
Mandelbrot Set Viewer

### DIFF
--- a/applications/ReadMe.md
+++ b/applications/ReadMe.md
@@ -19,6 +19,7 @@
 - `lfrfid`              - LF RFID application
 - `lfrfid_debug`        - LF RFID debug tool
 - `loader`              - Application loader service
+- `mandelbrot`          - Mandelbrot Set Viewer
 - `music_player`        - Music player app (demo)
 - `nfc`                 - NFC application, HF rfid, EMV and etc
 - `notification`        - Notification service 

--- a/applications/mandelbrot/application.fam
+++ b/applications/mandelbrot/application.fam
@@ -1,0 +1,10 @@
+App(
+    appid="mandelbrot",
+    name="Mandelbrot set",
+    apptype=FlipperAppType.GAME,
+    entry_point="mandelbrot_app",
+    cdefines=["APP_MANDELBROT_GAME"],
+    requires=["gui"],
+    stack_size=1 * 1024,
+    order=50,
+)

--- a/applications/mandelbrot/mandelbrot.c
+++ b/applications/mandelbrot/mandelbrot.c
@@ -1,0 +1,167 @@
+#include <furi.h>
+#include <math.h>
+#include <gui/gui.h>
+#include <input/input.h>
+#include <stdlib.h>
+
+typedef enum {
+    EventTypeTick,
+    EventTypeKey,
+} EventType;
+
+typedef struct {
+    EventType type;
+    InputEvent input;
+} PluginEvent;
+
+typedef struct {
+    float xZoom;
+    float yZoom;
+    float xOffset;
+    float yOffset;
+    float zoom;
+} PluginState; 
+
+bool mandelbrot_pixel(int x, int y, float xZoom, float yZoom, float xOffset, float yOffset){     
+
+    float ratio = 128.0 / 64.0;
+    //x0 := scaled x coordinate of pixel (scaled to lie in the Mandelbrot X scale (-2.00, 0.47))
+    float x0 = (((x/128.0) * ratio * xZoom)) - xOffset;
+    //y0 := scaled y coordinate of pixel (scaled to lie in the Mandelbrot Y scale (-1.12, 1.12))
+    float y0 = ((y/64.0) * yZoom) - yOffset;
+    float x1 = 0.0;
+    float y1 = 0.0;
+    float x2 = 0.0;
+    float y2 = 0.0;
+
+    int iteration = 0;
+    int max_iteration = 50;
+
+    while (x2 + y2 <= 4.0 && iteration < max_iteration){
+        y1 = 2.0 * x1 * y1 + y0;
+        x1 = x2 - y2 + x0;
+        x2 = x1 * x1;
+        y2 = y1 * y1;
+        iteration++;
+    }
+
+    if (iteration > 49){
+        return true;
+    }
+
+    return false;
+}
+
+
+static void render_callback(Canvas* const canvas, void* ctx) {
+    const PluginState* plugin_state = acquire_mutex((ValueMutex*)ctx, 25);
+    if(plugin_state == NULL) {
+        return;
+    }
+    // border around the edge of the screen
+    canvas_draw_frame(canvas, 0, 0, 128, 64);
+
+    for(int y = 0; y < 64; y++){
+        for(int x = 0; x < 128; x++){
+            // did you know if you just pass the indivdiual bits of plugin_state instead of plugin_state
+            // you dont get any compiler warnings :)
+            if (mandelbrot_pixel(x,y, plugin_state->xZoom, plugin_state->yZoom, plugin_state->xOffset, plugin_state->yOffset)){
+                canvas_draw_dot(canvas, x,y);
+            }
+        }
+    }
+
+
+    release_mutex((ValueMutex*)ctx, plugin_state);
+}
+
+static void input_callback(InputEvent* input_event, osMessageQueueId_t event_queue) {
+    furi_assert(event_queue); 
+
+    PluginEvent event = {.type = EventTypeKey, .input = *input_event};
+    osMessageQueuePut(event_queue, &event, 0, osWaitForever);
+}
+
+static void mandelbrot_state_init(PluginState* const plugin_state) {
+    plugin_state->xOffset = 3.0; 
+    plugin_state->yOffset = 1.12;
+    plugin_state->xZoom = 2.47;
+    plugin_state->yZoom = 2.24;
+    plugin_state->zoom = 1; // this controls the camera when 
+} 
+
+int32_t mandelbrot_app(void* p) { 
+    UNUSED(p);
+
+    osMessageQueueId_t event_queue = osMessageQueueNew(8, sizeof(PluginEvent), NULL); 
+    
+    PluginState* plugin_state = malloc(sizeof(PluginState));
+    mandelbrot_state_init(plugin_state);
+    ValueMutex state_mutex; 
+    if (!init_mutex(&state_mutex, plugin_state, sizeof(PluginState))) {
+        FURI_LOG_E("mandelbrot", "cannot create mutex\r\n");
+        free(plugin_state); 
+        return 255;
+    }
+
+    // Set system callbacks
+    ViewPort* view_port = view_port_alloc(); 
+    view_port_draw_callback_set(view_port, render_callback, &state_mutex);
+    view_port_input_callback_set(view_port, input_callback, event_queue);
+ 
+    // Open GUI and register view_port
+    Gui* gui = furi_record_open("gui"); 
+    gui_add_view_port(gui, view_port, GuiLayerFullscreen); 
+
+   
+    PluginEvent event; 
+    for(bool processing = true; processing;) { 
+        osStatus_t event_status = osMessageQueueGet(event_queue, &event, NULL, 100);
+        PluginState* plugin_state = (PluginState*)acquire_mutex_block(&state_mutex);
+
+        if(event_status == osOK) {
+            // press events
+            if(event.type == EventTypeKey) {
+                if(event.input.type == InputTypePress) {  
+                    switch(event.input.key) {
+                    case InputKeyUp: 
+                            plugin_state->yOffset += 0.1 / plugin_state->zoom;
+                        break; 
+                    case InputKeyDown: 
+                            plugin_state->yOffset += -0.1 / plugin_state->zoom;
+                        break; 
+                    case InputKeyRight: 
+                            plugin_state->xOffset += -0.1 / plugin_state->zoom;
+                        break; 
+                    case InputKeyLeft:  
+                            plugin_state->xOffset += 0.1 / plugin_state->zoom;
+                        break; 
+                    case InputKeyOk: 
+                            plugin_state->xZoom -= (2.47 / 10 )/ plugin_state->zoom;
+                            plugin_state->yZoom -= (2.24 / 10) / plugin_state->zoom;
+                            // used to make camera control finer the more zoomed you are
+                            // this needs to be some sort of curve
+                            plugin_state->zoom += 0.15; 
+                        break;
+                    case InputKeyBack: 
+                        processing = false;
+                        break;
+                    }
+                }
+            } 
+        } else {
+            FURI_LOG_D("mandelbrot", "osMessageQueue: event timeout");
+            // event timeout
+        }
+        view_port_update(view_port);
+        release_mutex(&state_mutex, plugin_state);
+    }
+
+    view_port_enabled_set(view_port, false);
+    gui_remove_view_port(gui, view_port);
+    furi_record_close("gui");
+    view_port_free(view_port);
+    osMessageQueueDelete(event_queue); 
+
+    return 0;
+}

--- a/applications/meta/application.fam
+++ b/applications/meta/application.fam
@@ -57,6 +57,7 @@ App(
         "tictactoe_game",
         "videopoker_game",
         "flappy_game","gameoflife_game","raycast_game",
+        "mandelbrot",
     ],
 )
 


### PR DESCRIPTION
# What's new

- Mandelbrot Viewer Plugin 
- Arrows control camera
- Middle button zooms camera

Currently using a pretty slow and inefficient algorithm. I know how crazy the optimisation for this can get so I've gone simple for now. But getting higher zoom levels is something to be looked at. The zoom curve needs to be refined too. 

It also completely locks up the flipper when zooming in on the central blob. Perhaps a maximum zoom limit must be set. I feel like this must be fixed before being merged but I'm not sure what's causing it at the moment, so I'd appreciate some help.

# Verification 

![Screenshot-20220711-015048](https://user-images.githubusercontent.com/12588174/178169658-5337732c-9140-4c33-b0ec-4493abb43739.png)
![Screenshot-20220711-015055](https://user-images.githubusercontent.com/12588174/178169660-20c4d25a-af46-4a5e-8619-b93d487f2d3c.png)
![Screenshot-20220711-015615](https://user-images.githubusercontent.com/12588174/178169890-c6c35f8e-0a1f-439f-92c3-418cb3762acd.png)


# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
