### PR TITLE
Log MFC nonces for use with mfkey32v2

### DIFF
--- a/lib/nfc_protocols/mifare_classic.c
+++ b/lib/nfc_protocols/mifare_classic.c
@@ -621,6 +621,20 @@ bool mf_classic_emulator(MfClassicEmulator* emulator, FuriHalNfcTxRxContext* tx_
                 command_processed = true;
                 break;
             }
+            
+            uint32_t nr = nfc_util_bytes2num(tx_rx->rx_data, 4);
+            uint32_t ar = nfc_util_bytes2num(&tx_rx->rx_data[4], 4);
+
+            FURI_LOG_D(
+                TAG,
+                "%08x key%c block %d nt/nr/ar: %08x %08x %08x",
+                emulator->cuid,
+                access_key == MfClassicKeyA ? 'A' : 'B',
+                sector_trailer_block,
+                nonce,
+                nr,
+                ar);
+
 
             // Check if we store valid key
             if(access_key == MfClassicKeyA) {
@@ -637,8 +651,7 @@ bool mf_classic_emulator(MfClassicEmulator* emulator, FuriHalNfcTxRxContext* tx_
                 }
             }
 
-            uint32_t nr = nfc_util_bytes2num(tx_rx->rx_data, 4);
-            uint32_t ar = nfc_util_bytes2num(&tx_rx->rx_data[4], 4);
+
             crypto1_word(&emulator->crypto, nr, 1);
             uint32_t cardRr = ar ^ crypto1_word(&emulator->crypto, 0, 0);
             if(cardRr != prng_successor(nonce, 64)) {


### PR DESCRIPTION

Adds a debug log with the nonce, nr, ar that can be used with mfkey32v2 to calculate a mifare classic key.

- Enable debug
- Increase log level to debug
- UID emulate mifare classic card
- open CLI and start log
- present to reader
- see log lines like:

`70795 [D][MfClassic]: 939be0d5 keyA block 3 nt/nr/ar: 4e70d691 b3a576be 02c1559b`
`77521 [D][MfClassic]: 939be0d5 keyA block 3 nt/nr/ar: c6efb126 d24dd966 03fc7386`

- Download and compile mfkey32v2 [LINK](https://github.com/equipter/mfkey32v2)

- example: UID 939be0d5`
- run `./mfkey32v2 with parameters like such ./mfkey32v2 [uid] [topline log] [bottomline log]` 

your command should look like this: `./mfkey32v2 939be0d5 4e70d691 b3a576be 02c1559b c6efb126 d24dd966 03fc7386`

your key should be popped out like so `Found Key: [a0a1a2a3a4a5]`
your keyA for Sector 3 is: a0a1a2a3a4a5
