### PR TITLE
Added condition to cli "log" command

### DIFF
--- a/applications/cli/cli_commands.c
+++ b/applications/cli/cli_commands.c
@@ -152,7 +152,7 @@ void cli_command_log(Cli* cli, string_t args, void* context) {
     furi_hal_console_set_tx_callback(cli_command_log_tx_callback, ring);
 
     printf("Press CTRL+C to stop...\r\n");
-    while(!cli_cmd_interrupt_received(cli)) {
+    while(!cli_cmd_interrupt_received(cli) && cli_is_connected(cli)) {
         size_t ret = xStreamBufferReceive(ring, buffer, CLI_COMMAND_LOG_BUFFER_SIZE, 50);
         cli_write(cli, buffer, ret);
     }


### PR DESCRIPTION
# What's new

- If USB is disconnected while "log" command is running, it will end the command. This is a change in cli_commands.c under cli_command_log function.

# Verification 

One way to verify:
- Connect to cli using serial terminal over USB
- Run log cli command
- Disconnect USB while log is still running
- Reconnect USB and reconnect to serial terminal over USB
- User should be prompted with normal cli prompt instead of a running log command.

Second way to verify
- Connect to cli using serial terminal over USB
- Run log cli command
- Disconnect from serial terminal while log is still running
- Reconnect to serial terminal over USB
- User should be prompted with normal cli prompt instead of a running log command.

Additional Verification:
- User should still be able to end log command using Ctrl+C break.

Note:
- If the original functionality of cli_command_log is to keep running while the serial terminal is disconnected, please feel free to decline this PR.

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
