### PR TITLE
Feature: game_2048 hold center to restart

### DIFF
--- a/applications/game2048/game_2048.c
+++ b/applications/game2048/game_2048.c
@@ -323,6 +323,19 @@ static void game_2048_process_move(GameState* const game_state) {
     // </debug>
 }
 
+static void game_2048_restart(GameState* const game_state) {
+    // clear all cells
+    for(uint8_t y = 0; y < 4; y++) {
+        for(uint8_t x = 0; x < 4; x++) {
+            game_state->field[y][x] = 0;
+        }
+    }
+
+    // start next game
+    game_2048_set_new_number(game_state);
+    game_2048_set_new_number(game_state);
+}
+
 int32_t game_2048_app(void* p) {
     int32_t return_code = 0;
 
@@ -399,7 +412,9 @@ int32_t game_2048_app(void* p) {
                     game_2048_process_move(game_state);
                     game_2048_set_new_number(game_state);
                     break;
-                case InputKeyOk:; // TODO: reinit in game ower state
+                case InputKeyOk:
+                    game_state->direction = DirectionIdle;
+                    game_2048_restart(game_state);
                     break;
                 case InputKeyBack:
                     loop = false;

--- a/applications/game2048/game_2048.c
+++ b/applications/game2048/game_2048.c
@@ -391,7 +391,7 @@ int32_t game_2048_app(void* p) {
         GameState* game_state = (GameState*)acquire_mutex_block(&state_mutex);
 
         if(event_status == FuriStatusOk) {
-            if(event.type == InputTypePress) {
+            if(event.type == InputTypeShort) {
                 switch(event.key) {
                 case InputKeyUp:
                     game_state->direction = DirectionUp;
@@ -415,11 +415,15 @@ int32_t game_2048_app(void* p) {
                     break;
                 case InputKeyOk:
                     game_state->direction = DirectionIdle;
-                    game_2048_restart(game_state);
                     break;
                 case InputKeyBack:
                     loop = false;
                     break;
+                }
+            } else if(event.type == InputTypeLong) {
+                if(event.key == InputKeyOk) {
+                    game_state->direction = DirectionIdle;
+                    game_2048_restart(game_state);
                 }
             }
         }

--- a/applications/game2048/game_2048.c
+++ b/applications/game2048/game_2048.c
@@ -337,6 +337,7 @@ static void game_2048_restart(GameState* const game_state) {
 }
 
 int32_t game_2048_app(void* p) {
+    UNUSED(p);
     int32_t return_code = 0;
 
     FuriMessageQueue* event_queue = furi_message_queue_alloc(8, sizeof(InputEvent));


### PR DESCRIPTION
# What's new

- At any point in game_2048, hold center to restart (clear all cells, add 2 numbers)

# Verification 

- I have tested this build on my personal flipper by navigating to the "2048" plugin, playing a bit, and holding center.

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
