### PR TITLE
BadUSB: add SYSRQ keys

### DIFF
--- a/applications/bad_usb/bad_usb_script.c
+++ b/applications/bad_usb/bad_usb_script.c
@@ -109,6 +109,7 @@ static const char ducky_cmd_string[] = {"STRING "};
 static const char ducky_cmd_defdelay_1[] = {"DEFAULT_DELAY "};
 static const char ducky_cmd_defdelay_2[] = {"DEFAULTDELAY "};
 static const char ducky_cmd_repeat[] = {"REPEAT "};
+static const char ducky_cmd_sysrq[] = {"SYSRQ "};
 
 static const char ducky_cmd_altchar[] = {"ALTCHAR "};
 static const char ducky_cmd_altstr_1[] = {"ALTSTRING "};
@@ -292,6 +293,14 @@ static int32_t ducky_parse_line(BadUsbScript* bad_usb, string_t line) {
         line_tmp = &line_tmp[ducky_get_command_len(line_tmp) + 1];
         state = ducky_get_number(line_tmp, &bad_usb->repeat_cnt);
         return (state) ? (0) : SCRIPT_STATE_ERROR;
+    } else if(strncmp(line_tmp, ducky_cmd_sysrq, strlen(ducky_cmd_sysrq)) == 0) {
+        // SYSRQ
+        line_tmp = &line_tmp[ducky_get_command_len(line_tmp) + 1];
+        uint16_t key = ducky_get_keycode(line_tmp, true);
+        furi_hal_hid_kb_press(KEY_MOD_LEFT_ALT | HID_KEYBOARD_PRINT_SCREEN);
+        furi_hal_hid_kb_press(key);
+        furi_hal_hid_kb_release_all();
+        return (0);
     } else {
         // Special keys + modifiers
         uint16_t key = ducky_get_keycode(line_tmp, false);


### PR DESCRIPTION
This allows sending of SysRq keys[1]. This then for example allows
sending the well known 'reisub' commands to safely reboot a otherwise
frozen Linux box. Or obviously any of the other magic keys.

The advantage compared to sending it to /proc/sysrq-trigger is that one
does not need a shell and depending on how broken the system is, one
might not even be able to get a new shell. The SysRq keys still work.

The cost is adding a new/"non-standard" keyword, IMO it is worth it.

Example:
DEFAULTDELAY 200
DELAY 1000
SYSRQ r
SYSRQ e
SYSRQ i
SYSRQ s
SYSRQ u
SYSRQ b

If one really wants to test it, I suggest h(elp) or w(ait).

[1] https://en.wikipedia.org/wiki/Magic_SysRq_key

# What's new

- [ Describe changes here ]

# Verification 

- [ Describe how to verify changes ]

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
