### PR TITLE
Add settings to subghz read functionality to allow setting RSSI threshold (raw only)

### DIFF
--- a/lib/subghz/protocols/raw.h
+++ b/lib/subghz/protocols/raw.h
@@ -35,6 +35,20 @@ bool subghz_protocol_raw_save_to_file_init(
 void subghz_protocol_decoder_raw_set_auto_mode(void* context, bool auto_mode);
 
 /**
+ * Set RSSI threshold ("sensitivity" level).
+ * @param context Pointer to a SubGhzProtocolDecoderRAW instance
+ * @param rssi_threshold The desired RSSI threshold
+ */
+void subghz_protocol_decoder_raw_set_rssi_threshold(void* context, int rssi_threshold);
+
+/**
+ * Get RSSI threshold ("sensitivity" level).
+ * @param context Pointer to a SubGhzProtocolDecoderRAW instance
+ * @return rssi threshold in db
+ */
+int subghz_protocol_encoder_get_rssi_threshold(void* context);
+
+/**
  * Stop writing file to flash
  * @param instance Pointer to a SubGhzProtocolDecoderRAW instance
  */


### PR DESCRIPTION
# What's new

- Adds an additional settings field to the subghz application where RSSI level can be set.
- Affects "detect raw" mode only.
- Aimed to filter out noise, i.e. "false positive" readings on 300Mhz.

**Note:** I tried to go lower than default threshold (-100 instead of -72) but this messed up the detection, causing faults. Going higher causes no issues so far.

# Verification 

- Open subghz application.
- Go to "read".
- Go to "config".
- Select noisy frequency.
- Enable "detect raw".
- Set desired RSSI level/threshold (-72db is default, so go higher in 5db increments).
- Noise should not trigger detection, i.e. only strong signals are detected.

![Screenshot-20220805-223918](https://user-images.githubusercontent.com/6267267/183159422-9b04328f-d08e-40d0-9dd0-e75fffffd453.png)

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
