### PR TITLE
Added ability to type spaces with the input keyboard

### DIFF
--- a/applications/gui/modules/text_input.c
+++ b/applications/gui/modules/text_input.c
@@ -133,8 +133,7 @@ static bool char_is_lowercase(char letter) {
 static char char_to_uppercase(const char letter) {
     if(letter == BACKSPACE_KEY) {
         return 0x20;
-    }
-    else if(isalpha(letter)) {
+    } else if(isalpha(letter)) {
         return (letter - 0x20);
     } else {
         return letter;

--- a/applications/gui/modules/text_input.c
+++ b/applications/gui/modules/text_input.c
@@ -131,7 +131,10 @@ static bool char_is_lowercase(char letter) {
 }
 
 static char char_to_uppercase(const char letter) {
-    if(isalpha(letter)) {
+    if(letter == BACKSPACE_KEY) {
+        return 0x20;
+    }
+    else if(isalpha(letter)) {
         return (letter - 0x20);
     } else {
         return letter;

--- a/applications/gui/modules/text_input.c
+++ b/applications/gui/modules/text_input.c
@@ -131,7 +131,7 @@ static bool char_is_lowercase(char letter) {
 }
 
 static char char_to_uppercase(const char letter) {
-    if(letter == BACKSPACE_KEY) {
+    if(letter == '_') {
         return 0x20;
     } else if(isalpha(letter)) {
         return (letter - 0x20);


### PR DESCRIPTION
Added ability to type spaces with the input keyboard by long-pressing `_`.

# What's new

- You can now input a space by long-pressing `_` (comparable to how you type uppercase letters).

# Verification 

- Open any input field (i.e. rename a SubGHz file).
- Long-press `_`.
- A space will be added to the input field.

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
