### PR TITLE
fix: exit games menu

### DIFF
--- a/applications/loader/loader.c
+++ b/applications/loader/loader.c
@@ -321,7 +321,8 @@ static Loader* loader_alloc() {
     // Games menu
     instance->games_menu = submenu_alloc();
     view_set_context(submenu_get_view(instance->games_menu), instance->games_menu);
-    view_set_previous_callback(submenu_get_view(instance->games_menu), loader_hide_menu);
+    view_set_previous_callback(
+        submenu_get_view(instance->games_menu), loader_back_to_primary_menu);
     view_dispatcher_add_view(
         instance->view_dispatcher, LoaderMenuViewGames, submenu_get_view(instance->games_menu));
     // Plugins menu


### PR DESCRIPTION
# What's new

- Changed set previous callback from `loader_hide_menu` to `loader_back_to_primary_menu` for games menu

# Verification 

- Go to games menu and press the back button

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
