### PR TITLE
game2048 scores uint16 -> uint32 for higher vals

### DIFF
--- a/applications/game2048/game_2048.c
+++ b/applications/game2048/game_2048.c
@@ -53,8 +53,8 @@ typedef struct {
 } Point;
 
 typedef struct {
-    uint16_t gameScore;
-    uint16_t highScore;
+    uint32_t gameScore;
+    uint32_t highScore;
 } Score;
 
 typedef struct {
@@ -112,14 +112,14 @@ static void game_2048_render_callback(Canvas* const canvas, ValueMutex* const vm
         }
 
         // display score
-        char buffer[6];
-        snprintf(buffer, sizeof(buffer), "%u", game_state->score.gameScore);
-        canvas_draw_str_aligned(canvas, 126, 8, AlignRight, AlignBottom, buffer);
+        char buffer[12];
+        snprintf(buffer, sizeof(buffer), "%lu", game_state->score.gameScore);
+        canvas_draw_str_aligned(canvas, 127, 8, AlignRight, AlignBottom, buffer);
 
         if(game_state->score.highScore > 0) {
-            char buffer2[6];
-            snprintf(buffer2, sizeof(buffer2), "%u", game_state->score.highScore);
-            canvas_draw_str_aligned(canvas, 126, 62, AlignRight, AlignBottom, buffer2);
+            char buffer2[12];
+            snprintf(buffer2, sizeof(buffer2), "%lu", game_state->score.highScore);
+            canvas_draw_str_aligned(canvas, 127, 62, AlignRight, AlignBottom, buffer2);
         }
     } else { // if animation
         // for animation
@@ -412,12 +412,12 @@ int32_t game_2048_app(void* p) {
         game_state->field[1][1] = 2;
         game_state->field[1][2] = 3;
         game_state->field[1][3] = 4;
-        
+
         game_state->field[2][0] = 5;
         game_state->field[2][1] = 6;
         game_state->field[2][2] = 7;
         game_state->field[2][3] = 8;
-        
+
         game_state->field[3][0] = 9;
         game_state->field[3][1] = 10;
         game_state->field[3][2] = 11;


### PR DESCRIPTION
# What's new

- unit16 was proving to be too small and would loop back to zero, crushing your high score. Also small formatting.

# Verification 

- Tested upwards of 500,000 via debug mode

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
