### PR TITLE
Force Restart on Battery Display setting change

### DIFF
--- a/applications/desktop/desktop_settings/scenes/desktop_settings_scene_start.c
+++ b/applications/desktop/desktop_settings/scenes/desktop_settings_scene_start.c
@@ -37,6 +37,8 @@ const char* const battery_view_count_text[BATTERY_VIEW_COUNT] = {
 };
 const uint32_t displayBatteryPercentage_value[BATTERY_VIEW_COUNT] = {0, 1, 2, 3, 4};
 
+uint8_t  origBattDisp_value = 0;
+
 #define DUMBMODE_COUNT 2
 const char* const dumbmode_text[DUMBMODE_COUNT] = {
     "OFF",
@@ -77,6 +79,7 @@ static void desktop_settings_scene_start_dumbmode_changed(VariableItem* item) {
 void desktop_settings_scene_start_on_enter(void* context) {
     DesktopSettingsApp* app = context;
     VariableItemList* variable_item_list = app->variable_item_list;
+	origBattDisp_value = app->settings.displayBatteryPercentage;
 
     VariableItem* item;
     uint8_t value_index;
@@ -174,4 +177,9 @@ void desktop_settings_scene_start_on_exit(void* context) {
     DesktopSettingsApp* app = context;
     variable_item_list_reset(app->variable_item_list);
     SAVE_DESKTOP_SETTINGS(&app->settings);
+	
+	if(app->settings.displayBatteryPercentage != origBattDisp_value)
+	{
+		furi_hal_power_reset();
+	}
 }


### PR DESCRIPTION
# What's new
- Added a check in Desktop Settings, that if Battery Display value is changed, it'll force a restart.

# Verification 
- Change Battery Display setting in Settings > Desktop
- Back out of Desktop settings
- If the Battery Display value is changed, the FlipperZero will restart
- If the Battery Display value is the same as previously set, no restart occurs.

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
