### PR TITLE
Fix BT Address with custom name

### DIFF
--- a/firmware/targets/f7/furi_hal/furi_hal_version.c
+++ b/firmware/targets/f7/furi_hal/furi_hal_version.c
@@ -86,55 +86,30 @@ typedef struct {
     char name[FURI_HAL_VERSION_ARRAY_NAME_LENGTH]; /** \0 terminated name */
     char device_name[FURI_HAL_VERSION_DEVICE_NAME_LENGTH]; /** device name for special needs */
     uint8_t ble_mac[6];
-    const char* cname;
 } FuriHalVersion;
 
 static FuriHalVersion furi_hal_version = {0};
 
 static void furi_hal_version_set_name(const char* name) {
-    furi_hal_version.cname = furi_hal_version_get_name_ptr();
-    if (strlen(furi_hal_version.cname)<=0) furi_hal_version.cname=NULL;
     if(name != NULL) {
-        if(name != furi_hal_version.cname && furi_hal_version.cname==NULL) {
-            strlcpy(
-                furi_hal_version.name, 
-                name, 
-                FURI_HAL_VERSION_ARRAY_NAME_LENGTH);
-            snprintf(
-                furi_hal_version.device_name,
-                FURI_HAL_VERSION_DEVICE_NAME_LENGTH,
-                "xFlipper %s",
-                name);
-        } else if(name != furi_hal_version.cname && furi_hal_version.cname!=NULL) {
-            strlcpy(
-                furi_hal_version.name, 
-                furi_hal_version.cname, 
-                FURI_HAL_VERSION_ARRAY_NAME_LENGTH);
-            snprintf(
-                furi_hal_version.device_name,
-                FURI_HAL_VERSION_DEVICE_NAME_LENGTH,
-                "xFlipper %s",
-                furi_hal_version.name);
-        } else {
-            strlcpy(
-                furi_hal_version.name,
-                furi_hal_version.cname,
-                FURI_HAL_VERSION_ARRAY_NAME_LENGTH);
-            snprintf(
-                furi_hal_version.device_name,
-                FURI_HAL_VERSION_DEVICE_NAME_LENGTH,
-                "xFlipper %s",
-                furi_hal_version.name);
-        }
+        strlcpy(furi_hal_version.name, name, FURI_HAL_VERSION_ARRAY_NAME_LENGTH);
+        snprintf(
+            furi_hal_version.device_name,
+            FURI_HAL_VERSION_DEVICE_NAME_LENGTH,
+            "xFlipper %s",
+            furi_hal_version.name);
     } else {
-        snprintf(furi_hal_version.device_name, FURI_HAL_VERSION_DEVICE_NAME_LENGTH, "xFlipper Dev");
+        snprintf(furi_hal_version.device_name, FURI_HAL_VERSION_DEVICE_NAME_LENGTH, "xFlipper");
     }
 
     furi_hal_version.device_name[0] = AD_TYPE_COMPLETE_LOCAL_NAME;
 
     // BLE Mac address
     uint32_t udn = LL_FLASH_GetUDN();
-    udn = (uint32_t)*name;
+    if(version_get_custom_name(NULL) != NULL) {
+        udn = (uint32_t)*version_get_custom_name(NULL);
+    }
+
     uint32_t company_id = LL_FLASH_GetSTCompanyID();
     uint32_t device_id = LL_FLASH_GetDeviceID();
     furi_hal_version.ble_mac[0] = (uint8_t)(udn & 0x000000FF);
@@ -158,9 +133,8 @@ static void furi_hal_version_load_otp_v0() {
     furi_hal_version.board_body = otp->board_body;
     furi_hal_version.board_connect = otp->board_connect;
 
-    furi_hal_version.cname = furi_hal_version_get_name_ptr();
-    if(furi_hal_version.cname != NULL && strlen(furi_hal_version.cname)>=1 && strlen(furi_hal_version.cname)<=8) {
-        furi_hal_version_set_name(furi_hal_version.cname);
+    if(version_get_custom_name(NULL) != NULL) {
+        furi_hal_version_set_name(version_get_custom_name(NULL));
     } else {
         furi_hal_version_set_name(otp->name);
     }
@@ -177,9 +151,8 @@ static void furi_hal_version_load_otp_v1() {
     furi_hal_version.board_color = otp->board_color;
     furi_hal_version.board_region = otp->board_region;
 
-    furi_hal_version.cname = furi_hal_version_get_name_ptr();
-    if(furi_hal_version.cname != NULL && strlen(furi_hal_version.cname)>=1 && strlen(furi_hal_version.cname)<=8) {
-        furi_hal_version_set_name(furi_hal_version.cname);
+    if(version_get_custom_name(NULL) != NULL) {
+        furi_hal_version_set_name(version_get_custom_name(NULL));
     } else {
         furi_hal_version_set_name(otp->name);
     }
@@ -202,9 +175,8 @@ static void furi_hal_version_load_otp_v2() {
     if(otp->board_color != 0xFF) {
         furi_hal_version.board_color = otp->board_color;
         furi_hal_version.board_region = otp->board_region;
-        furi_hal_version.cname = furi_hal_version_get_name_ptr();
-        if(furi_hal_version.cname != NULL && strlen(furi_hal_version.cname)>=1 && strlen(furi_hal_version.cname)<=8) {
-            furi_hal_version_set_name(furi_hal_version.cname);
+        if(version_get_custom_name(NULL) != NULL) {
+            furi_hal_version_set_name(version_get_custom_name(NULL));
         } else {
             furi_hal_version_set_name(otp->name);
         }
@@ -321,16 +293,7 @@ uint32_t furi_hal_version_get_hw_timestamp() {
 }
 
 const char* furi_hal_version_get_name_ptr() {
-    furi_hal_version.cname = version_get_custom_name(NULL);
-    if (furi_hal_version.cname!=NULL && strlen(furi_hal_version.cname)>=1 && strlen(furi_hal_version.cname)<=8) {
-        return furi_hal_version.cname;
-    } else {
-        return *furi_hal_version.name == 0x00 ? NULL : furi_hal_version.name;
-    }
-    // return "N4V1RUK4";
-    // return "N00BY";
-    // return "CH33CH";
-    // return "CH0NG";
+    return *furi_hal_version.name == 0x00 ? NULL : furi_hal_version.name;
 }
 
 const char* furi_hal_version_get_device_name_ptr() {
@@ -354,9 +317,8 @@ size_t furi_hal_version_uid_size() {
 }
 
 const uint8_t* furi_hal_version_uid() {
-    furi_hal_version.cname = furi_hal_version_get_name_ptr();
-    if(furi_hal_version.cname != NULL && strlen(furi_hal_version.cname)>=1 && strlen(furi_hal_version.cname)<=8) {
-        return (const uint8_t*)((uint32_t)*furi_hal_version_get_name_ptr());
+    if(version_get_custom_name(NULL) != NULL) {
+        return (const uint8_t*)((uint32_t)*version_get_custom_name(NULL));
     }
     return (const uint8_t*)UID64_BASE;
 }


### PR DESCRIPTION
fixes BT address with custom name #233 

# What's new

- fixes custom name working with bluetooth MAC address to protect user privacy

# Verification 

- compiled "stock" flipper and custom named flipper, BT addresses differ.

# Checklist (For Reviewer)

- [x] I've built this code, uploaded it to the device and verified feature/bugfix
