### PR TITLE
Flipper Name Changer - Initial Upload

### DIFF
--- a/applications/namechanger/application.fam
+++ b/applications/namechanger/application.fam
@@ -1,0 +1,19 @@
+App(
+    appid="APPS_NameChanger",
+    name="Name Changer",
+    apptype=FlipperAppType.PLUGIN,
+    entry_point="namechanger_app",
+    cdefines=["APP_NAMECHANGER"],
+    requires=["gui","dialogs","storage",],
+    provides=["namechanger_start"],
+    stack_size=2 * 1024,
+    order=169,
+)
+
+App(
+    appid="namechanger_start",
+    apptype=FlipperAppType.STARTUP,
+    entry_point="namechanger_on_system_start",
+    requires=["storage"],
+    order=130,
+)

--- a/applications/namechanger/namechanger.c
+++ b/applications/namechanger/namechanger.c
@@ -1,0 +1,488 @@
+#include "namechanger.h"
+#include "namechanger_i.h"
+#include "namechanger/scenes/namechanger_scene.h"
+#include "m-string.h"
+#include <toolbox/path.h>
+#include <flipper_format/flipper_format.h>
+
+bool namechanger_make_app_folder(NameChanger* namechanger)
+{
+	bool created = false;
+	
+	string_t folderpath;
+	string_init_set_str(folderpath,"/ext/dolphin");
+	
+	//Make dir if doesn't exist
+	if(!storage_simply_mkdir(namechanger->storage, string_get_cstr(folderpath)))
+	{
+		dialog_message_show_storage_error(namechanger->dialogs, "Cannot create\napp folder.");
+	}
+	else
+	{
+		created = true;
+	}
+	
+	string_clear(folderpath);
+	return created;
+}
+
+bool namechanger_name_read_write(NameChanger* namechanger, char* name, uint8_t mode)
+{
+    FlipperFormat* file = flipper_format_file_alloc(namechanger->storage);
+	
+	string_t file_path;
+	string_init_set_str(file_path,"/ext/dolphin/name.txt");
+	
+	if(namechanger_make_app_folder(namechanger))
+	{
+		if(mode == 2)
+		{
+			//read
+			bool result = false;
+			
+			string_t data;
+			string_init(data);
+			
+			do
+			{
+				if(!flipper_format_file_open_existing(file, string_get_cstr(file_path)))
+				{
+					break;
+				}
+				
+				// header
+				uint32_t version;
+				
+				if(!flipper_format_read_header(file, data, &version))
+				{
+					break;
+				}
+				
+				if(string_cmp_str(data, NAMECHANGER_HEADER) != 0)
+				{
+					break;
+				}
+				
+				if(version != 1)
+				{
+					break;
+				}
+				
+				// get Name
+				if(!flipper_format_read_string(file, "Name", data))
+				{
+					break;
+				}
+				
+				result = true;
+			} while(false);
+			
+			flipper_format_free(file);
+			
+			if(!result)
+			{
+				FURI_LOG_I(TAG,"Cannot load file.");
+			}
+			else
+			{
+				string_strim(data);
+				FURI_LOG_I(TAG,"data: %s", data);
+	
+				namechanger_text_store_set(namechanger, "%s", string_get_cstr(data));
+			}
+			
+			string_clear(data);
+				
+			return result;
+		}
+		else if(mode == 3)
+		{
+			//save
+			FlipperFormat* file = flipper_format_file_alloc(namechanger->storage);
+			
+			bool result = false;
+			
+			do
+			{
+				// Open file for write
+				if(!flipper_format_file_open_always(file, string_get_cstr(file_path)))
+				{
+					break;
+				}
+			
+				// Write header
+				if(!flipper_format_write_header_cstr(file, NAMECHANGER_HEADER, 1))
+				{
+					break;
+				}
+				
+				// Write comments
+				if(!flipper_format_write_comment_cstr(file, "Changing the value below will change your FlipperZero device name."))
+				{
+					break;
+				}
+				
+				if(!flipper_format_write_comment_cstr(file, "Note: This is limited to 8 characters using the following: a-z, A-Z, 0-9, and _"))
+				{
+					break;
+				}
+					
+				if(!flipper_format_write_comment_cstr(file, "It cannot contain any other characters."))
+				{
+					break;
+				}
+				
+				//Write name
+				if(!flipper_format_write_string_cstr(file, "Name", name))
+				{
+					break;
+				}
+			
+				result = true;
+			} while(false);
+			
+			flipper_format_free(file);
+			
+			if(!result)
+			{
+				//dialog_message_show_storage_error(namechanger->dialogs, "Cannot save\nname file");
+				FURI_LOG_I(TAG,"Cannot save name file.");
+			}
+			else
+			{
+				//set name
+				furi_hal_version_set_custom_name(name);
+			}
+			
+			return result;
+		}
+		else
+		{
+			FURI_LOG_I(TAG,"Something broke.");
+			return false;
+		}
+	}
+	else
+	{
+		dialog_message_show_storage_error(namechanger->dialogs, "Cannot create\napp folder.");
+		return false;
+	}
+}
+
+bool namechanger_custom_event_callback(void* context, uint32_t event) {
+    furi_assert(context);
+    NameChanger* namechanger = context;
+    return scene_manager_handle_custom_event(namechanger->scene_manager, event);
+}
+
+bool namechanger_back_event_callback(void* context) {
+    furi_assert(context);
+    NameChanger* namechanger = context;
+    return scene_manager_handle_back_event(namechanger->scene_manager);
+}
+
+void namechanger_tick_event_callback(void* context) {
+    furi_assert(context);
+    NameChanger* namechanger = context;
+    scene_manager_handle_tick_event(namechanger->scene_manager);
+}
+
+NameChanger* namechanger_alloc()
+{
+	NameChanger* namechanger = malloc(sizeof(namechanger));
+
+    namechanger->scene_manager = scene_manager_alloc(&namechanger_scene_handlers, namechanger);
+
+    namechanger->view_dispatcher = view_dispatcher_alloc();
+    view_dispatcher_enable_queue(namechanger->view_dispatcher);
+    view_dispatcher_set_event_callback_context(namechanger->view_dispatcher, namechanger);
+    view_dispatcher_set_custom_event_callback(
+        namechanger->view_dispatcher, namechanger_custom_event_callback);
+    view_dispatcher_set_navigation_event_callback(
+        namechanger->view_dispatcher, namechanger_back_event_callback);
+    view_dispatcher_set_tick_event_callback(
+        namechanger->view_dispatcher, namechanger_tick_event_callback, 500);
+
+    namechanger->gui = furi_record_open(RECORD_GUI);
+    namechanger->storage = furi_record_open(RECORD_STORAGE);
+    namechanger->dialogs = furi_record_open(RECORD_DIALOGS);
+
+    namechanger->text_input = text_input_alloc();
+    view_dispatcher_add_view(
+        namechanger->view_dispatcher, NameChangerViewTextInput, text_input_get_view(namechanger->text_input));
+
+    namechanger->popup = popup_alloc();
+    view_dispatcher_add_view(
+        namechanger->view_dispatcher, NameChangerViewPopup, popup_get_view(namechanger->popup));
+
+    namechanger->widget = widget_alloc();
+    view_dispatcher_add_view(
+        namechanger->view_dispatcher, NameChangerViewWidget, widget_get_view(namechanger->widget));
+
+    namechanger->dialog_ex = dialog_ex_alloc();
+    view_dispatcher_add_view(
+        namechanger->view_dispatcher, NameChangerViewDialogEx, dialog_ex_get_view(namechanger->dialog_ex));
+
+    return namechanger;
+}
+
+void namechanger_free(NameChanger* namechanger) {
+    furi_assert(namechanger);
+
+    view_dispatcher_remove_view(namechanger->view_dispatcher, NameChangerViewDialogEx);
+    dialog_ex_free(namechanger->dialog_ex);
+	
+    view_dispatcher_remove_view(namechanger->view_dispatcher, NameChangerViewWidget);
+    widget_free(namechanger->widget);
+
+    view_dispatcher_remove_view(namechanger->view_dispatcher, NameChangerViewPopup);
+    popup_free(namechanger->popup);
+
+    view_dispatcher_remove_view(namechanger->view_dispatcher, NameChangerViewTextInput);
+    text_input_free(namechanger->text_input);
+
+    view_dispatcher_free(namechanger->view_dispatcher);
+    scene_manager_free(namechanger->scene_manager);
+
+    furi_record_close(RECORD_STORAGE);
+    namechanger->storage = NULL;
+	
+    furi_record_close(RECORD_DIALOGS);
+    namechanger->dialogs = NULL;
+
+    furi_record_close(RECORD_GUI);
+    namechanger->gui = NULL;
+
+    free(namechanger);
+}
+
+bool namechanger_delete_file(NameChanger* namechanger, char* file_path)
+{
+    bool result = false;
+    result = storage_simply_remove(namechanger->storage, file_path);
+
+    return result;
+}
+
+void namechanger_text_store_set(NameChanger* namechanger, const char* text, ...) {
+    va_list args;
+    va_start(args, text);
+
+    vsnprintf(namechanger->text_store, NAMECHANGER_TEXT_STORE_SIZE, text, args);
+
+    va_end(args);
+}
+
+void namechanger_text_store_clear(NameChanger* namechanger) {
+    memset(namechanger->text_store, 0, NAMECHANGER_TEXT_STORE_SIZE);
+}
+
+int32_t namechanger_app(void* p) {
+	UNUSED(p);
+	FURI_LOG_I(TAG,"app1");
+    NameChanger* namechanger = namechanger_alloc();
+
+	FURI_LOG_I(TAG,"app2");
+    view_dispatcher_attach_to_gui(namechanger->view_dispatcher, namechanger->gui, ViewDispatcherTypeFullscreen);
+	
+	scene_manager_next_scene(namechanger->scene_manager, NameChangerSceneSaveName);
+
+	view_dispatcher_run(namechanger->view_dispatcher);
+	
+	namechanger_free(namechanger);
+    return 0;
+}
+
+void namechanger_on_system_start()
+{
+	Storage* storage = furi_record_open(RECORD_STORAGE);
+    FlipperFormat* file = flipper_format_file_alloc(storage);
+	
+	string_t NAMEHEADER;
+	string_init_set_str(NAMEHEADER,"Flipper Name File");
+	
+	string_t folderpath;
+	string_init_set_str(folderpath,"/ext/dolphin");
+	
+	string_t filepath;
+	string_init_set_str(filepath,"/ext/dolphin/name.txt");
+	
+	//Make dir if doesn't exist
+	if(storage_simply_mkdir(storage, string_get_cstr(folderpath)))
+	{
+		bool result = false;
+		
+		string_t data;
+		string_init(data);
+		
+		do
+		{
+			if(!flipper_format_file_open_existing(file, string_get_cstr(filepath)))
+			{
+				break;
+			}
+			
+			// header
+			uint32_t version;
+			
+			if(!flipper_format_read_header(file, data, &version))
+			{
+				break;
+			}
+			
+			if(string_cmp_str(data, string_get_cstr(NAMEHEADER)) != 0)
+			{
+				break;
+			}
+			
+			if(version != 1)
+			{
+				break;
+			}
+			
+			// get Name
+			if(!flipper_format_read_string(file, "Name", data))
+			{
+				break;
+			}
+			
+			result = true;
+		} while(false);
+		
+		flipper_format_free(file);
+		
+		if(!result)
+		{
+			//file not good - write new one
+			FlipperFormat* file = flipper_format_file_alloc(storage);
+			
+			bool res = false;
+			
+			string_t name;
+			string_init_set_str(name, furi_hal_version_get_name_ptr());
+			
+			do
+			{
+				// Open file for write
+				if(!flipper_format_file_open_always(file, string_get_cstr(filepath)))
+				{
+					break;
+				}
+			
+				// Write header
+				if(!flipper_format_write_header_cstr(file, string_get_cstr(NAMEHEADER), 1))
+				{
+					break;
+				}
+				
+				// Write comments
+				if(!flipper_format_write_comment_cstr(file, "Changing the value below will change your FlipperZero device name."))
+				{
+					break;
+				}
+				
+				if(!flipper_format_write_comment_cstr(file, "Note: This is limited to 8 characters using the following: a-z, A-Z, 0-9, and _"))
+				{
+					break;
+				}
+					
+				if(!flipper_format_write_comment_cstr(file, "It can contain other characters but use at your own risk."))
+				{
+					break;
+				}
+				
+				//Write name
+				if(!flipper_format_write_string_cstr(file, "Name", string_get_cstr(name)))
+				{
+					break;
+				}
+			
+				res = true;
+			} while(false);
+			
+			flipper_format_free(file);
+			
+			if(!res)
+			{
+				FURI_LOG_E(TAG, "Save failed.");
+			}
+			
+			string_clear(name);
+		}
+		else
+		{
+			string_strim(data);
+			FURI_LOG_I(TAG,"data: %s", data);
+
+			if(!string_size(data))
+			{
+				//Empty file - get default name and write to file.
+				FlipperFormat* file = flipper_format_file_alloc(storage);
+				
+				bool res = false;
+				
+				string_t name;
+				string_init_set_str(name, furi_hal_version_get_name_ptr());
+				
+				do
+				{
+					// Open file for write
+					if(!flipper_format_file_open_always(file, string_get_cstr(filepath)))
+					{
+						break;
+					}
+				
+					// Write header
+					if(!flipper_format_write_header_cstr(file, string_get_cstr(NAMEHEADER), 1))
+					{
+						break;
+					}
+					
+					// Write comments
+					if(!flipper_format_write_comment_cstr(file, "Changing the value below will change your FlipperZero device name."))
+					{
+						break;
+					}
+					
+					if(!flipper_format_write_comment_cstr(file, "Note: This is limited to 8 characters using the following: a-z, A-Z, 0-9, and _"))
+					{
+						break;
+					}
+					
+					if(!flipper_format_write_comment_cstr(file, "It cannot contain any other characters."))
+					{
+						break;
+					}
+					
+					//Write name
+					if(!flipper_format_write_string_cstr(file, "Name", string_get_cstr(name)))
+					{
+						break;
+					}
+				
+					res = true;
+				} while(false);
+				
+				flipper_format_free(file);
+				
+				if(!res)
+				{
+					FURI_LOG_E(TAG, "Save failed.");
+				}
+				
+				string_clear(name);
+			}
+			else
+			{
+				//set name from file
+				furi_hal_version_set_custom_name(string_get_cstr(data));
+			}
+		}
+
+		string_clear(data);
+	}
+	
+	string_clear(filepath);
+	string_clear(folderpath);
+	furi_record_close(RECORD_STORAGE);
+}

--- a/applications/namechanger/namechanger.h
+++ b/applications/namechanger/namechanger.h
@@ -1,0 +1,3 @@
+#pragma once
+
+typedef struct NameChanger NameChanger;

--- a/applications/namechanger/namechanger_custom_event.h
+++ b/applications/namechanger/namechanger_custom_event.h
@@ -1,0 +1,6 @@
+#pragma once
+
+enum NameChangerCustomEvent {
+    NameChangerCustomEventBack,
+    NameChangerCustomEventTextEditResult,
+};

--- a/applications/namechanger/namechanger_i.h
+++ b/applications/namechanger/namechanger_i.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <furi_hal.h>
+#include "namechanger.h"
+#include <gui/gui.h>
+#include <gui/view.h>
+#include <gui/view_dispatcher.h>
+#include <gui/scene_manager.h>
+#include <storage/storage.h>
+#include <dialogs/dialogs.h>
+#include <gui/modules/popup.h>
+#include <gui/modules/dialog_ex.h>
+#include <gui/modules/text_input.h>
+#include <gui/modules/widget.h>
+
+#include "namechanger_custom_event.h"
+#include "scenes/namechanger_scene.h"
+
+#define NAMECHANGER_TEXT_STORE_SIZE 9
+#define NAMECHANGER_HEADER "Flipper Name File"
+
+#define TAG "NameChanger"
+
+struct NameChanger {
+    SceneManager* scene_manager;
+    ViewDispatcher* view_dispatcher;
+
+    Gui* gui;
+    Storage* storage;
+    DialogsApp* dialogs;
+
+    char text_store[NAMECHANGER_TEXT_STORE_SIZE+1];
+
+    TextInput* text_input;
+    Popup* popup;
+    Widget* widget;
+    DialogEx* dialog_ex;
+};
+
+typedef enum {
+    NameChangerViewTextInput,
+    NameChangerViewPopup,
+    NameChangerViewWidget,
+    NameChangerViewDialogEx,
+} NameChangerView;
+
+bool namechanger_name_read_write(NameChanger* namechanger, char* name, uint8_t mode);
+void namechanger_text_store_set(NameChanger* namechanger, const char* text, ...);
+void namechanger_text_store_clear(NameChanger* namechanger);

--- a/applications/namechanger/scenes/namechanger_scene.c
+++ b/applications/namechanger/scenes/namechanger_scene.c
@@ -1,0 +1,30 @@
+#include "namechanger_scene.h"
+
+// Generate scene on_enter handlers array
+#define ADD_SCENE(prefix, name, id) prefix##_scene_##name##_on_enter,
+void (*const namechanger_on_enter_handlers[])(void*) = {
+#include "namechanger_scene_config.h"
+};
+#undef ADD_SCENE
+
+// Generate scene on_event handlers array
+#define ADD_SCENE(prefix, name, id) prefix##_scene_##name##_on_event,
+bool (*const namechanger_on_event_handlers[])(void* context, SceneManagerEvent event) = {
+#include "namechanger_scene_config.h"
+};
+#undef ADD_SCENE
+
+// Generate scene on_exit handlers array
+#define ADD_SCENE(prefix, name, id) prefix##_scene_##name##_on_exit,
+void (*const namechanger_on_exit_handlers[])(void* context) = {
+#include "namechanger_scene_config.h"
+};
+#undef ADD_SCENE
+
+// Initialize scene handlers configuration structure
+const SceneManagerHandlers namechanger_scene_handlers = {
+    .on_enter_handlers = namechanger_on_enter_handlers,
+    .on_event_handlers = namechanger_on_event_handlers,
+    .on_exit_handlers = namechanger_on_exit_handlers,
+    .scene_num = NameChangerSceneNum,
+};

--- a/applications/namechanger/scenes/namechanger_scene.h
+++ b/applications/namechanger/scenes/namechanger_scene.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <gui/scene_manager.h>
+
+// Generate scene id and total number
+#define ADD_SCENE(prefix, name, id) NameChangerScene##id,
+typedef enum {
+#include "namechanger_scene_config.h"
+    NameChangerSceneNum,
+} NameChangerScene;
+#undef ADD_SCENE
+
+extern const SceneManagerHandlers namechanger_scene_handlers;
+
+// Generate scene on_enter handlers declaration
+#define ADD_SCENE(prefix, name, id) void prefix##_scene_##name##_on_enter(void*);
+#include "namechanger_scene_config.h"
+#undef ADD_SCENE
+
+// Generate scene on_event handlers declaration
+#define ADD_SCENE(prefix, name, id) \
+    bool prefix##_scene_##name##_on_event(void* context, SceneManagerEvent event);
+#include "namechanger_scene_config.h"
+#undef ADD_SCENE
+
+// Generate scene on_exit handlers declaration
+#define ADD_SCENE(prefix, name, id) void prefix##_scene_##name##_on_exit(void* context);
+#include "namechanger_scene_config.h"
+#undef ADD_SCENE

--- a/applications/namechanger/scenes/namechanger_scene_config.h
+++ b/applications/namechanger/scenes/namechanger_scene_config.h
@@ -1,0 +1,3 @@
+ADD_SCENE(namechanger, save_name, SaveName)
+ADD_SCENE(namechanger, save_success, SaveSuccess)
+ADD_SCENE(namechanger, save_failed, SaveFailed)

--- a/applications/namechanger/scenes/namechanger_scene_save_failed.c
+++ b/applications/namechanger/scenes/namechanger_scene_save_failed.c
@@ -1,0 +1,49 @@
+#include "../namechanger_i.h"
+#include <dolphin/dolphin.h>
+
+static void namechanger_scene_save_failed_popup_callback(void* context) {
+    NameChanger* namechanger = context;
+    view_dispatcher_send_custom_event(namechanger->view_dispatcher, NameChangerCustomEventBack);
+}
+
+void namechanger_scene_save_failed_on_enter(void* context) {
+    NameChanger* namechanger = context;
+    Popup* popup = namechanger->popup;
+
+    popup_set_icon(popup, 5, 10, &I_Cry_dolph_55x52);
+    popup_set_header(popup, "Save", 80, 20, AlignLeft, AlignTop);
+    popup_set_text(popup, "Failed.", 80, 35, AlignLeft, AlignTop);
+
+    popup_set_callback(popup, namechanger_scene_save_failed_popup_callback);
+    popup_set_context(popup, namechanger);
+    popup_set_timeout(popup, 5000);
+    popup_enable_timeout(popup);
+
+    view_dispatcher_switch_to_view(namechanger->view_dispatcher, NameChangerViewPopup);
+}
+
+bool namechanger_scene_save_failed_on_event(void* context, SceneManagerEvent event) {
+    NameChanger* namechanger = context;
+    bool consumed = false;
+
+    if(event.type == SceneManagerEventTypeCustom) {
+        consumed = true;
+        if(event.event == NameChangerCustomEventBack) {
+            scene_manager_search_and_switch_to_previous_scene(namechanger->scene_manager, NameChangerSceneSaveName);
+        }
+    }
+
+    return consumed;
+}
+
+void namechanger_scene_save_failed_on_exit(void* context) {
+    NameChanger* namechanger = context;
+    Popup* popup = namechanger->popup;
+
+    popup_set_text(popup, NULL, 0, 0, AlignCenter, AlignTop);
+    popup_set_icon(popup, 0, 0, NULL);
+
+    popup_disable_timeout(popup);
+    popup_set_context(popup, NULL);
+    popup_set_callback(popup, NULL);
+}

--- a/applications/namechanger/scenes/namechanger_scene_save_name.c
+++ b/applications/namechanger/scenes/namechanger_scene_save_name.c
@@ -1,0 +1,52 @@
+#include "../namechanger_i.h"
+#include "m-string.h"
+#include <toolbox/path.h>
+
+static void namechanger_scene_save_name_text_input_callback(void* context) {
+    NameChanger* namechanger = context;
+    view_dispatcher_send_custom_event(namechanger->view_dispatcher, NameChangerCustomEventTextEditResult);
+}
+
+void namechanger_scene_save_name_on_enter(void* context) {
+    NameChanger* namechanger = context;
+    TextInput* text_input = namechanger->text_input;
+	
+	bool file_exists = namechanger_name_read_write(namechanger, NULL, 2);
+
+    text_input_set_header_text(text_input, "Set Flipper Name");
+    text_input_set_result_callback(
+		text_input,
+		namechanger_scene_save_name_text_input_callback,
+		namechanger,
+        namechanger->text_store,
+		NAMECHANGER_TEXT_STORE_SIZE,
+        file_exists);
+
+    view_dispatcher_switch_to_view(namechanger->view_dispatcher, NameChangerViewTextInput);
+}
+
+bool namechanger_scene_save_name_on_event(void* context, SceneManagerEvent event) {
+    NameChanger* namechanger = context;
+    bool consumed = false;
+
+    if(event.type == SceneManagerEventTypeCustom) {
+        consumed = true;
+        if(event.event == NameChangerCustomEventTextEditResult) {
+            if(namechanger_name_read_write(namechanger, namechanger->text_store, 3)) {
+                scene_manager_next_scene(namechanger->scene_manager, NameChangerSceneSaveSuccess);
+            } else {
+                scene_manager_search_and_switch_to_previous_scene(
+                    namechanger->scene_manager, NameChangerSceneSaveFailed);
+            }
+        }
+    }
+
+    return consumed;
+}
+
+void namechanger_scene_save_name_on_exit(void* context) {
+    NameChanger* namechanger = context;
+    TextInput* text_input = namechanger->text_input;
+
+    text_input_reset(text_input);
+}

--- a/applications/namechanger/scenes/namechanger_scene_save_success.c
+++ b/applications/namechanger/scenes/namechanger_scene_save_success.c
@@ -1,0 +1,50 @@
+#include "../namechanger_i.h"
+#include <dolphin/dolphin.h>
+
+static void namechanger_scene_save_success_popup_callback(void* context) {
+    NameChanger* namechanger = context;
+    view_dispatcher_send_custom_event(namechanger->view_dispatcher, NameChangerCustomEventBack);
+}
+
+void namechanger_scene_save_success_on_enter(void* context) {
+    NameChanger* namechanger = context;
+    Popup* popup = namechanger->popup;
+
+    popup_set_icon(popup, 32, 5, &I_DolphinNice_96x59);
+    popup_set_header(popup, "Saved!", 5, 7, AlignLeft, AlignTop);
+
+    popup_set_callback(popup, namechanger_scene_save_success_popup_callback);
+    popup_set_context(popup, namechanger);
+    popup_set_timeout(popup, 5000);
+    popup_enable_timeout(popup);
+
+    view_dispatcher_switch_to_view(namechanger->view_dispatcher, NameChangerViewPopup);
+}
+
+bool namechanger_scene_save_success_on_event(void* context, SceneManagerEvent event) {
+	//UNUSED(context);
+	NameChanger* namechanger = context;
+    bool consumed = false;
+
+    if(event.type == SceneManagerEventTypeCustom) {
+        consumed = true;
+        if(event.event == NameChangerCustomEventBack) {
+            scene_manager_search_and_switch_to_previous_scene(namechanger->scene_manager, NameChangerSceneSaveName);
+			//furi_hal_power_reset();
+        }
+    }
+
+    return consumed;
+}
+
+void namechanger_scene_save_success_on_exit(void* context) {
+    NameChanger* namechanger = context;
+    Popup* popup = namechanger->popup;
+
+    popup_set_text(popup, NULL, 0, 0, AlignCenter, AlignTop);
+    popup_set_icon(popup, 0, 0, NULL);
+
+    popup_disable_timeout(popup);
+    popup_set_context(popup, NULL);
+    popup_set_callback(popup, NULL);
+}

--- a/firmware/targets/f7/furi_hal/furi_hal_version.c
+++ b/firmware/targets/f7/furi_hal/furi_hal_version.c
@@ -91,43 +91,73 @@ typedef struct {
 
 static FuriHalVersion furi_hal_version = {0};
 
-static void furi_hal_version_set_name(const char* name) {
-    furi_hal_version.cname = furi_hal_version_get_name_ptr();
-    if (strlen(furi_hal_version.cname)<=0) furi_hal_version.cname=NULL;
-    if(name != NULL) {
-        if(name != furi_hal_version.cname && furi_hal_version.cname==NULL) {
-            strlcpy(
-                furi_hal_version.name, 
-                name, 
-                FURI_HAL_VERSION_ARRAY_NAME_LENGTH);
-            snprintf(
-                furi_hal_version.device_name,
-                FURI_HAL_VERSION_DEVICE_NAME_LENGTH,
-                "xFlipper %s",
-                name);
-        } else if(name != furi_hal_version.cname && furi_hal_version.cname!=NULL) {
-            strlcpy(
-                furi_hal_version.name, 
-                furi_hal_version.cname, 
-                FURI_HAL_VERSION_ARRAY_NAME_LENGTH);
-            snprintf(
-                furi_hal_version.device_name,
-                FURI_HAL_VERSION_DEVICE_NAME_LENGTH,
-                "xFlipper %s",
-                furi_hal_version.name);
-        } else {
-            strlcpy(
-                furi_hal_version.name,
-                furi_hal_version.cname,
-                FURI_HAL_VERSION_ARRAY_NAME_LENGTH);
-            snprintf(
-                furi_hal_version.device_name,
-                FURI_HAL_VERSION_DEVICE_NAME_LENGTH,
-                "xFlipper %s",
-                furi_hal_version.name);
-        }
-    } else {
-        snprintf(furi_hal_version.device_name, FURI_HAL_VERSION_DEVICE_NAME_LENGTH, "xFlipper Dev");
+void furi_hal_version_set_custom_name(const char* name)
+{
+	if((name != NULL) && ((strlen(name) >= 1) && (strlen(name) <= 8)))
+	{
+		strlcpy(furi_hal_version.name, name, FURI_HAL_VERSION_ARRAY_NAME_LENGTH);
+		snprintf(furi_hal_version.device_name, FURI_HAL_VERSION_DEVICE_NAME_LENGTH, "xFlipper %s", name);
+
+		furi_hal_version.device_name[0] = AD_TYPE_COMPLETE_LOCAL_NAME;
+	}
+}
+
+void furi_hal_version_set_name(const char* name) {
+	furi_hal_version.cname = version_get_custom_name(NULL);
+	
+    if((furi_hal_version.cname != NULL) && !((strlen(furi_hal_version.cname) >=1) && (strlen(furi_hal_version.cname) <= 8)))
+	{
+		furi_hal_version.cname = NULL;
+	}
+
+	if(name != NULL)
+	{
+		if(furi_hal_version.cname != NULL)
+		{
+			strlcpy(
+				furi_hal_version.name, 
+				furi_hal_version.cname, 
+				FURI_HAL_VERSION_ARRAY_NAME_LENGTH);
+					
+			snprintf(
+				furi_hal_version.device_name,
+				FURI_HAL_VERSION_DEVICE_NAME_LENGTH,
+				"xFlipper %s",
+				furi_hal_version.name);
+		}
+		else
+		{
+			strlcpy(
+				furi_hal_version.name,
+				name,
+				FURI_HAL_VERSION_ARRAY_NAME_LENGTH);
+			
+			snprintf(
+				furi_hal_version.device_name,
+				FURI_HAL_VERSION_DEVICE_NAME_LENGTH,
+				"xFlipper %s",
+				furi_hal_version.name);
+		}
+	}
+	else
+	{
+		if(furi_hal_version.cname != NULL)
+		{
+			strlcpy(
+				furi_hal_version.name, 
+				furi_hal_version.cname, 
+				FURI_HAL_VERSION_ARRAY_NAME_LENGTH);
+					
+			snprintf(
+				furi_hal_version.device_name,
+				FURI_HAL_VERSION_DEVICE_NAME_LENGTH,
+				"xFlipper %s",
+				furi_hal_version.name);
+		}
+		else
+		{
+			snprintf(furi_hal_version.device_name, FURI_HAL_VERSION_DEVICE_NAME_LENGTH, "xFlipper Device");
+		}
     }
 
     furi_hal_version.device_name[0] = AD_TYPE_COMPLETE_LOCAL_NAME;
@@ -321,12 +351,7 @@ uint32_t furi_hal_version_get_hw_timestamp() {
 }
 
 const char* furi_hal_version_get_name_ptr() {
-    furi_hal_version.cname = version_get_custom_name(NULL);
-    if (furi_hal_version.cname!=NULL && strlen(furi_hal_version.cname)>=1 && strlen(furi_hal_version.cname)<=8) {
-        return furi_hal_version.cname;
-    } else {
-        return *furi_hal_version.name == 0x00 ? NULL : furi_hal_version.name;
-    }
+    return *furi_hal_version.name == 0x00 ? NULL : furi_hal_version.name;
 }
 
 const char* furi_hal_version_get_device_name_ptr() {

--- a/firmware/targets/furi_hal_include/furi_hal_version.h
+++ b/firmware/targets/furi_hal_include/furi_hal_version.h
@@ -51,9 +51,13 @@ typedef enum {
     FuriHalVersionDisplayMgg = 0x02,
 } FuriHalVersionDisplay;
 
-/** Set Flipper name
+/** Set name Name
  */
-// void furi_hal_version_set_name();
+void furi_hal_version_set_name(const char* name);
+
+/** Set Custom Name
+ */
+void furi_hal_version_set_custom_name(const char* name);
 
 /** Init flipper version
  */

--- a/firmware/targets/furi_hal_include/furi_hal_version.h
+++ b/firmware/targets/furi_hal_include/furi_hal_version.h
@@ -51,7 +51,7 @@ typedef enum {
     FuriHalVersionDisplayMgg = 0x02,
 } FuriHalVersionDisplay;
 
-/** Set name Name
+/** Set Flipper Name
  */
 void furi_hal_version_set_name(const char* name);
 


### PR DESCRIPTION
# What's new
## Flipper Name Changer
### Initial Upload
- Didn't upload modified meta/applications.fam. Use `APPS_NameChanger`
- Still causes HardFaults sometimes
- Creates and uses `name.txt` file located in `/ext/dolphin/` folder (Uses special format)
- Runs a function at system start to check name file and apply custom name if file exists.
-- If file doesn't exist, file is created with current name (default or CUSTOM_FLIPPER_NAME)
- Requires the uploaded/modified furi_hal_version files
- Modified furi_hal_version will keep CUSTOM_FLIPPER_NAME modification, but NameChanger will overwrite local name if name.txt exists at startup (minus Bluetooth name)

# Verification 

### Method 1
- Run NameChanger app and change name.
- Name will save to file, and apply to device immediately (minus Bluetooth name)

### Additional Checks 1
- If no `name.txt` file exists, NameChanger will use default device name or hardcoded CUSTOM_FLIPPER_NAME
- `name.txt` will be created and saved with the name

### Additional Checks 2
- If `name.txt` file exists, NameChanger will update device name to use the name in the file

### Additional Checks 3
- Modifying `name.txt` file and restarting the device will update the name.

**Note: No character protection in place currently.**

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
