### PR TITLE
Update name.txt for "Name Changer" Plugin

### DIFF
--- a/assets/resources/dolphin/name.txt
+++ b/assets/resources/dolphin/name.txt
@@ -2,5 +2,5 @@ Filetype: Flipper Name File
 Version: 1
 # Changing the value below will change your FlipperZero device name.
 # Note: This is limited to 8 characters using the following: a-z, A-Z, 0-9, and _
-# It can contain other characters but use at your own risk.
+# It cannot contain any other characters.
 Name: 


### PR DESCRIPTION
removed empty line at the end because it creates a format failure that causes flipper to crash

# What's new

Flipper "Name Changer" App is crashing because of an encoding/spacing issue in the name.txt file saving the file with a linux text editor solves the problem.

# Verification 

opened the file with a linux editor and saved the file again, no more crashes and renaming over the plugin does work now.

[name.txt](https://github.com/RogueMaster/flipperzero-firmware-wPlugins/files/9416857/name.txt)

