### PR TITLE
docs: fix relative file markdown links

### DIFF
--- a/documentation/HowToBuild.md
+++ b/documentation/HowToBuild.md
@@ -21,7 +21,7 @@ git clone --recursive https://github.com/RogueMaster/flipperzero-firmware-wPlugi
 
 ## Building
 
-Check out [documentation/fbt.md](documentation/fbt.md) for details on building and flashing firmware.
+Check out [documentation/fbt.md](fbt.md) for details on building and flashing firmware.
 
 ### Compile
 
@@ -47,7 +47,7 @@ Production standard Options
 	updater_package
 ```
 
-Usefull options, check `./fbt -h` and [fbt.md](documentation/fbt.md) for more
+Usefull options, check `./fbt -h` and [fbt.md](fbt.md) for more
 
 ```shell
 DEBUG=1 # Enable debug build


### PR DESCRIPTION
# What's new

- Make those links to `documentation/fbt.md` work

# Verification 

- Click the links on the Github UI, now they don't 404

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
