### PR TITLE
Save last used SubGHZ config settings

### DIFF
--- a/applications/subghz/scenes/subghz_scene_need_saving.c
+++ b/applications/subghz/scenes/subghz_scene_need_saving.c
@@ -50,8 +50,8 @@ bool subghz_scene_need_saving_on_event(void* context, SceneManagerEvent event) {
                 subghz->txrx->rx_key_state = SubGhzRxKeyStateIDLE;
                 subghz_preset_init(
                     subghz,
-                    "AM650",
-                    subghz_setting_get_default_frequency(subghz->setting),
+                    string_get_cstr(subghz->last_setting->preset_name),
+                    subghz->last_setting->frequency,
                     NULL,
                     0);
                 scene_manager_search_and_switch_to_previous_scene(

--- a/applications/subghz/scenes/subghz_scene_read_raw.c
+++ b/applications/subghz/scenes/subghz_scene_read_raw.c
@@ -114,6 +114,10 @@ bool subghz_scene_read_raw_on_event(void* context, SceneManagerEvent event) {
     if(event.type == SceneManagerEventTypeCustom) {
         switch(event.event) {
         case SubGhzCustomEventViewReadRAWBack:
+            // Check if return from config save values
+            if (subghz->current_scene == SubGhzSceneReceiverConfig) {
+                subghz_last_setting_save(subghz->last_setting, EXT_PATH("subghz/assets/last_used.txt"));
+            }
             //Stop TX
             if(subghz->txrx->txrx_state == SubGhzTxRxStateTx) {
                 subghz_tx_stop(subghz);
@@ -132,13 +136,14 @@ bool subghz_scene_read_raw_on_event(void* context, SceneManagerEvent event) {
             if((subghz->txrx->rx_key_state == SubGhzRxKeyStateAddKey) ||
                (subghz->txrx->rx_key_state == SubGhzRxKeyStateBack)) {
                 subghz->txrx->rx_key_state = SubGhzRxKeyStateExit;
+                subghz->current_scene = SubGhzSceneNeedSaving;
                 scene_manager_next_scene(subghz->scene_manager, SubGhzSceneNeedSaving);
             } else {
                 //Restore default setting
                 subghz_preset_init(
                     subghz,
-                    "AM650",
-                    subghz_setting_get_default_frequency(subghz->setting),
+                    string_get_cstr(subghz->last_setting->preset_name),
+                    subghz->last_setting->frequency,
                     NULL,
                     0);
                 if(!scene_manager_search_and_switch_to_previous_scene(
@@ -147,7 +152,11 @@ bool subghz_scene_read_raw_on_event(void* context, SceneManagerEvent event) {
                            subghz->scene_manager, SubGhzSceneStart)) {
                         scene_manager_stop(subghz->scene_manager);
                         view_dispatcher_stop(subghz->view_dispatcher);
+                    } else {
+                        subghz->current_scene = SubGhzSceneStart;
                     }
+                } else {
+                    subghz->current_scene = SubGhzSceneSaved;
                 }
             }
             consumed = true;
@@ -171,6 +180,7 @@ bool subghz_scene_read_raw_on_event(void* context, SceneManagerEvent event) {
         case SubGhzCustomEventViewReadRAWConfig:
             scene_manager_set_scene_state(
                 subghz->scene_manager, SubGhzSceneReadRAW, SubGhzCustomEventManagerSet);
+            subghz->current_scene = SubGhzSceneReceiverConfig;
             scene_manager_next_scene(subghz->scene_manager, SubGhzSceneReceiverConfig);
             consumed = true;
             break;
@@ -192,6 +202,7 @@ bool subghz_scene_read_raw_on_event(void* context, SceneManagerEvent event) {
                 scene_manager_set_scene_state(
                     subghz->scene_manager, SubGhzSceneReadRAW, SubGhzCustomEventManagerSet);
                 subghz->txrx->rx_key_state = SubGhzRxKeyStateRAWLoad;
+                subghz->current_scene = SubGhzSceneMoreRAW;
                 scene_manager_next_scene(subghz->scene_manager, SubGhzSceneMoreRAW);
                 consumed = true;
             } else {
@@ -211,6 +222,7 @@ bool subghz_scene_read_raw_on_event(void* context, SceneManagerEvent event) {
                    (subghz->txrx->txrx_state == SubGhzTxRxStateSleep)) {
                     if(!subghz_tx_start(subghz, subghz->txrx->fff_data)) {
                         subghz->txrx->rx_key_state = SubGhzRxKeyStateBack;
+                        subghz->current_scene = SubGhzSceneShowOnlyRx;
                         scene_manager_next_scene(subghz->scene_manager, SubGhzSceneShowOnlyRx);
                     } else {
                         DOLPHIN_DEED(DolphinDeedSubGhzSend);
@@ -290,6 +302,7 @@ bool subghz_scene_read_raw_on_event(void* context, SceneManagerEvent event) {
 
         case SubGhzCustomEventViewReadRAWREC:
             if(subghz->txrx->rx_key_state != SubGhzRxKeyStateIDLE) {
+                subghz->current_scene = SubGhzSceneNeedSaving;
                 scene_manager_next_scene(subghz->scene_manager, SubGhzSceneNeedSaving);
             } else {
                 uint32_t time = LL_RTC_TIME_Get(RTC); // 0x00HHMMSS
@@ -328,6 +341,7 @@ bool subghz_scene_read_raw_on_event(void* context, SceneManagerEvent event) {
                     subghz->txrx->rx_key_state = SubGhzRxKeyStateAddKey;
                 } else {
                     string_set_str(subghz->error_str, "Function requires\nan SD card.");
+                    subghz->current_scene = SubGhzSceneShowError;
                     scene_manager_next_scene(subghz->scene_manager, SubGhzSceneShowError);
                 }
             }
@@ -339,6 +353,7 @@ bool subghz_scene_read_raw_on_event(void* context, SceneManagerEvent event) {
                 scene_manager_set_scene_state(
                     subghz->scene_manager, SubGhzSceneReadRAW, SubGhzCustomEventManagerSetRAW);
                 subghz->txrx->rx_key_state = SubGhzRxKeyStateBack;
+                subghz->current_scene = SubGhzSceneSaveName;
                 scene_manager_next_scene(subghz->scene_manager, SubGhzSceneSaveName);
             }
             consumed = true;

--- a/applications/subghz/scenes/subghz_scene_receiver.c
+++ b/applications/subghz/scenes/subghz_scene_receiver.c
@@ -103,7 +103,11 @@ void subghz_scene_receiver_on_enter(void* context) {
 
     if(subghz->txrx->rx_key_state == SubGhzRxKeyStateIDLE) {
         subghz_preset_init(
-            subghz, "AM650", subghz_setting_get_default_frequency(subghz->setting), NULL, 0);
+            subghz,
+            string_get_cstr(subghz->last_setting->preset_name),
+            subghz->last_setting->frequency,
+            NULL,
+            0);
         subghz_history_reset(subghz->txrx->history);
         subghz->txrx->rx_key_state = SubGhzRxKeyStateStart;
     }
@@ -152,6 +156,10 @@ bool subghz_scene_receiver_on_event(void* context, SceneManagerEvent event) {
     if(event.type == SceneManagerEventTypeCustom) {
         switch(event.event) {
         case SubGhzCustomEventViewReceiverBack:
+            // Check if return from config save values
+            if (subghz->current_scene == SubGhzSceneReceiverConfig) {
+                subghz_last_setting_save(subghz->last_setting, EXT_PATH("subghz/assets/last_used.txt"));
+            }
             // Stop CC1101 Rx
             subghz->state_notifications = SubGhzNotificationStateIDLE;
             if(subghz->txrx->txrx_state == SubGhzTxRxStateRx) {
@@ -164,15 +172,17 @@ bool subghz_scene_receiver_on_event(void* context, SceneManagerEvent event) {
 
             if(subghz->txrx->rx_key_state == SubGhzRxKeyStateAddKey) {
                 subghz->txrx->rx_key_state = SubGhzRxKeyStateExit;
+                subghz->current_scene = SubGhzSceneNeedSaving;
                 scene_manager_next_scene(subghz->scene_manager, SubGhzSceneNeedSaving);
             } else {
                 subghz->txrx->rx_key_state = SubGhzRxKeyStateIDLE;
                 subghz_preset_init(
                     subghz,
-                    "AM650",
-                    subghz_setting_get_default_frequency(subghz->setting),
+                    string_get_cstr(subghz->last_setting->preset_name),
+                    subghz->last_setting->frequency,
                     NULL,
                     0);
+                subghz->current_scene = SubGhzSceneStart;
                 scene_manager_search_and_switch_to_previous_scene(
                     subghz->scene_manager, SubGhzSceneStart);
             }
@@ -181,6 +191,7 @@ bool subghz_scene_receiver_on_event(void* context, SceneManagerEvent event) {
         case SubGhzCustomEventViewReceiverOK:
             subghz->txrx->idx_menu_chosen =
                 subghz_view_receiver_get_idx_menu(subghz->subghz_receiver);
+            subghz->current_scene = SubGhzSceneReceiverInfo;
             scene_manager_next_scene(subghz->scene_manager, SubGhzSceneReceiverInfo);
             consumed = true;
             break;
@@ -188,6 +199,7 @@ bool subghz_scene_receiver_on_event(void* context, SceneManagerEvent event) {
             subghz->state_notifications = SubGhzNotificationStateIDLE;
             subghz->txrx->idx_menu_chosen =
                 subghz_view_receiver_get_idx_menu(subghz->subghz_receiver);
+            subghz->current_scene = SubGhzSceneReceiverConfig;
             scene_manager_next_scene(subghz->scene_manager, SubGhzSceneReceiverConfig);
             consumed = true;
             break;

--- a/applications/subghz/scenes/subghz_scene_receiver_config.c
+++ b/applications/subghz/scenes/subghz_scene_receiver_config.c
@@ -145,6 +145,8 @@ static void subghz_scene_receiver_config_set_frequency(VariableItem* item) {
             (subghz_setting_get_frequency(subghz->setting, index) % 1000000) / 10000);
         variable_item_set_current_value_text(item, text_buf);
         subghz->txrx->preset->frequency = subghz_setting_get_frequency(subghz->setting, index);
+        subghz->last_setting->frequency = subghz->txrx->preset->frequency;
+        subghz_setting_set_default_frequency(subghz->setting, subghz->txrx->preset->frequency);
     } else {
         variable_item_set_current_value_index(
             item, subghz_setting_get_frequency_default_index(subghz->setting));
@@ -154,11 +156,13 @@ static void subghz_scene_receiver_config_set_frequency(VariableItem* item) {
 static void subghz_scene_receiver_config_set_preset(VariableItem* item) {
     SubGhz* subghz = variable_item_get_context(item);
     uint8_t index = variable_item_get_current_value_index(item);
-    variable_item_set_current_value_text(
-        item, subghz_setting_get_preset_name(subghz->setting, index));
+    const char* preset_name = subghz_setting_get_preset_name(subghz->setting, index);
+    variable_item_set_current_value_text(item, preset_name);
+    string_set_str(subghz->last_setting->preset_name, preset_name);
+
     subghz_preset_init(
         subghz,
-        subghz_setting_get_preset_name(subghz->setting, index),
+        preset_name,
         subghz->txrx->preset->frequency,
         subghz_setting_get_preset_data(subghz->setting, index),
         subghz_setting_get_preset_data_size(subghz->setting, index));
@@ -173,6 +177,7 @@ static void subghz_scene_receiver_config_set_rssi_threshold(VariableItem* item) 
         subghz_receiver_search_decoder_base_by_name(
             subghz->txrx->receiver, SUBGHZ_PROTOCOL_RAW_NAME),
         rssi_threshold_value[index]);
+    subghz->last_setting->rssi_threshold = rssi_threshold_value[index];
 }
 
 static void subghz_scene_receiver_config_set_detect_raw(VariableItem* item) {
@@ -181,6 +186,7 @@ static void subghz_scene_receiver_config_set_detect_raw(VariableItem* item) {
 
     variable_item_set_current_value_text(item, detect_raw_text[index]);
     subghz_receiver_set_filter(subghz->txrx->receiver, detect_raw_value[index]);
+    subghz->last_setting->detect_raw = detect_raw_value[index];
 
     subghz_protocol_decoder_raw_set_auto_mode(
         subghz_receiver_search_decoder_base_by_name(
@@ -221,7 +227,7 @@ static void subghz_scene_receiver_config_set_hopping_running(VariableItem* item)
             subghz_setting_get_frequency_default_index(subghz->setting));
     }
 
-    subghz->txrx->hopper_state = hopping_value[index];
+    subghz->txrx->hopper_state = subghz->last_setting->hopping = hopping_value[index];
 }
 
 static void subghz_scene_receiver_config_var_list_enter_callback(void* context, uint32_t index) {

--- a/applications/subghz/subghz.c
+++ b/applications/subghz/subghz.c
@@ -174,16 +174,25 @@ SubGhz* subghz_alloc() {
     subghz->setting = subghz_setting_alloc();
     subghz_setting_load(subghz->setting, EXT_PATH("subghz/assets/setting_user.txt"));
 
+    // Load last used values for Read, Read RAW, etc. or default
+    subghz->last_setting = subghz_last_setting_alloc();
+    subghz_last_setting_load(subghz->last_setting, EXT_PATH("subghz/assets/last_used.txt"));
+    subghz_setting_set_default_frequency(subghz->setting, subghz->last_setting->frequency);
+
     //init Worker & Protocol & History & KeyBoard
     subghz->lock = SubGhzLockOff;
     subghz->txrx = malloc(sizeof(SubGhzTxRx));
     subghz->txrx->preset = malloc(sizeof(SubGhzPresetDefinition));
     string_init(subghz->txrx->preset->name);
     subghz_preset_init(
-        subghz, "AM650", subghz_setting_get_default_frequency(subghz->setting), NULL, 0);
+        subghz,
+        string_get_cstr(subghz->last_setting->preset_name),
+        subghz->last_setting->frequency,
+        NULL,
+        0);
 
     subghz->txrx->txrx_state = SubGhzTxRxStateSleep;
-    subghz->txrx->hopper_state = SubGhzHopperStateOFF;
+    subghz->txrx->hopper_state = subghz->last_setting->hopping;
     subghz->txrx->rx_key_state = SubGhzRxKeyStateIDLE;
     subghz->txrx->history = subghz_history_alloc();
     subghz->txrx->worker = subghz_worker_alloc();
@@ -196,7 +205,9 @@ SubGhz* subghz_alloc() {
     subghz_environment_set_nice_flor_s_rainbow_table_file_name(
         subghz->txrx->environment, EXT_PATH("subghz/assets/nice_flor_s"));
     subghz->txrx->receiver = subghz_receiver_alloc_init(subghz->txrx->environment);
-    subghz_receiver_set_filter(subghz->txrx->receiver, SubGhzProtocolFlag_Decodable);
+
+    // Setup values
+    subghz_last_setting_set_receiver_values(subghz->last_setting, subghz->txrx->receiver);
 
     subghz_worker_set_overrun_callback(
         subghz->txrx->worker, (SubGhzWorkerOverrunCallback)subghz_receiver_reset);
@@ -287,6 +298,9 @@ void subghz_free(SubGhz* subghz) {
 
     //setting
     subghz_setting_free(subghz->setting);
+
+    // Last setting
+    subghz_last_setting_free(subghz->last_setting);
 
     //Worker & Protocol & History
     subghz_receiver_free(subghz->txrx->receiver);

--- a/applications/subghz/subghz_i.h
+++ b/applications/subghz/subghz_i.h
@@ -33,6 +33,7 @@
 
 #include "subghz_history.h"
 #include "subghz_setting.h"
+#include "subghz_last_setting.h"
 
 #include <gui/modules/variable_item_list.h>
 #include <lib/toolbox/path.h>
@@ -100,10 +101,11 @@ struct SubGhz {
     SubGhzTestPacket* subghz_test_packet;
     string_t error_str;
     SubGhzSetting* setting;
+    SubGhzLastSetting* last_setting;
     SubGhzLock lock;
 
     bool in_decoder_scene;
-
+    SubGhzScene current_scene;
     void* rpc_ctx;
 };
 

--- a/applications/subghz/subghz_last_setting.c
+++ b/applications/subghz/subghz_last_setting.c
@@ -1,0 +1,141 @@
+#include "subghz_setting.h"
+#include "subghz_i.h"
+
+#include "subghz_last_setting.h"
+
+#include <furi.h>
+#include <m-list.h>
+#include "furi_hal_subghz.h"
+#include "furi_hal_subghz_configs.h"
+#include <lib/subghz/protocols/raw.h>
+
+#define TAG "SubGhzLastSetting"
+
+#define SUBGHZ_LAST_SETTING_FILE_TYPE "Flipper SubGhz Last Setting File"
+#define SUBGHZ_LAST_SETTING_FILE_VERSION 1
+#define SUBGHZ_LAST_SETTING_DEFAULT_PRESET "AM650"
+#define SUBGHZ_LAST_SETTING_DEFAULT_FREQUENCY 433920000
+
+SubGhzLastSetting* subghz_last_setting_alloc(void) {
+    SubGhzLastSetting* instance = malloc(sizeof(SubGhzLastSetting));
+    string_init(instance->preset_name);
+
+    return instance;
+}
+
+void subghz_last_setting_free(SubGhzLastSetting* instance) {
+    furi_assert(instance);
+
+    string_clear(instance->preset_name);
+    free(instance);
+}
+
+void subghz_last_setting_load(SubGhzLastSetting* instance, const char* file_path) {
+    furi_assert(instance);
+    string_init(instance->preset_name);
+
+    Storage* storage = furi_record_open(RECORD_STORAGE);
+    FlipperFormat* fff_data_file = flipper_format_file_alloc(storage);
+
+    string_t temp_preset;
+    string_init(temp_preset);
+    uint32_t temp_frequency = 0; // Default 433920000
+    uint32_t temp_hopping = 0; // Default 0
+    uint32_t temp_detect_raw = 0; // Default 2
+    int32_t temp_rssi_threshold = 0; // Default -72
+
+    if(FSE_OK == storage_sd_status(storage) &&
+       file_path &&
+       flipper_format_file_open_existing(fff_data_file, file_path)) {
+        flipper_format_read_string(fff_data_file, "Preset", temp_preset);
+        flipper_format_read_uint32(fff_data_file, "Frequency", (uint32_t*)&temp_frequency, 1);
+        flipper_format_read_uint32(fff_data_file, "Hopping", (uint32_t*)&temp_hopping, 1);
+        flipper_format_read_uint32(fff_data_file, "DetectRaw", (uint32_t*)&temp_detect_raw, 1);
+        flipper_format_read_int32(fff_data_file, "Rssi", (int32_t*)&temp_rssi_threshold, 1);
+    } else {
+        FURI_LOG_E(TAG, "Error open file %s", file_path);
+    }
+
+    if(string_empty_p(temp_preset)) {
+        FURI_LOG_I(TAG, "Last used preset not found");
+        string_set(instance->preset_name, SUBGHZ_LAST_SETTING_DEFAULT_PRESET);
+    } else {
+        string_set(instance->preset_name, temp_preset);
+    }
+
+    if(temp_frequency == 0 || !furi_hal_subghz_is_tx_allowed(temp_frequency)) {
+        FURI_LOG_I(TAG, "Last used frequency not found or can't be used!");
+        instance->frequency = SUBGHZ_LAST_SETTING_DEFAULT_FREQUENCY;
+    } else {
+        instance->frequency = temp_frequency;
+    }
+
+    if(temp_detect_raw == 0) {
+        instance->detect_raw = SubGhzProtocolFlag_Decodable;
+    } else {
+        instance->detect_raw = temp_detect_raw;
+    }
+
+    if (temp_rssi_threshold == 0) {
+        instance->rssi_threshold = -72;
+    } else {
+        instance->rssi_threshold = temp_rssi_threshold;
+    }
+    instance->hopping = temp_hopping;
+
+    string_clear(temp_preset);
+    flipper_format_free(fff_data_file);
+    furi_record_close(RECORD_STORAGE);
+}
+
+bool subghz_last_setting_save(SubGhzLastSetting* instance, const char* file_path) {
+    furi_assert(instance);
+
+    bool saved = false;
+    Storage* storage = furi_record_open(RECORD_STORAGE);
+    FlipperFormat* file = flipper_format_file_alloc(storage);
+
+    do {
+        if(FSE_OK != storage_sd_status(storage)) break;
+
+        // Delete prev file, because I didn't find solution to change preset if file already exists
+        storage_simply_remove(storage, file_path);
+
+        // Open file
+        if(!flipper_format_file_open_always(file, file_path)) break;
+
+        // Write header
+        if(!flipper_format_write_header_cstr(file, SUBGHZ_LAST_SETTING_FILE_TYPE, SUBGHZ_LAST_SETTING_FILE_VERSION))
+            break;
+
+        FURI_LOG_D(TAG, "Preset %s", string_get_cstr(instance->preset_name));
+        if(!flipper_format_write_string_cstr(file, "Preset", string_get_cstr(instance->preset_name))) break;
+        if(!flipper_format_write_uint32(file, "Frequency", &instance->frequency, 1)) break;
+        if(!flipper_format_write_uint32(file, "Hopping", &instance->hopping, 1)) break;
+        if(!flipper_format_write_uint32(file, "DetectRaw", &instance->detect_raw, 1)) break;
+        if(!flipper_format_write_int32(file, "Rssi", &instance->rssi_threshold, 1)) break;
+
+        saved = true;
+    } while(0);
+
+    if(!saved) {
+        FURI_LOG_E(TAG, "Error save file %s", file_path);
+    }
+
+    flipper_format_free(file);
+    furi_record_close(RECORD_STORAGE);
+
+    return saved;
+}
+
+void subghz_last_setting_set_receiver_values(SubGhzLastSetting* instance, SubGhzReceiver* receiver) {
+    subghz_receiver_set_filter(receiver, instance->detect_raw);
+
+    subghz_protocol_decoder_raw_set_auto_mode(
+        subghz_receiver_search_decoder_base_by_name(receiver, SUBGHZ_PROTOCOL_RAW_NAME),
+        (instance->detect_raw != SubGhzProtocolFlag_Decodable));
+
+    subghz_protocol_decoder_raw_set_rssi_threshold(
+        subghz_receiver_search_decoder_base_by_name(receiver, SUBGHZ_PROTOCOL_RAW_NAME),
+        instance->rssi_threshold);
+}

--- a/applications/subghz/subghz_last_setting.c
+++ b/applications/subghz/subghz_last_setting.c
@@ -98,9 +98,6 @@ bool subghz_last_setting_save(SubGhzLastSetting* instance, const char* file_path
     do {
         if(FSE_OK != storage_sd_status(storage)) break;
 
-        // Delete prev file, because I didn't find solution to change preset if file already exists
-        storage_simply_remove(storage, file_path);
-
         // Open file
         if(!flipper_format_file_open_always(file, file_path)) break;
 
@@ -109,11 +106,11 @@ bool subghz_last_setting_save(SubGhzLastSetting* instance, const char* file_path
             break;
 
         FURI_LOG_D(TAG, "Preset %s", string_get_cstr(instance->preset_name));
-        if(!flipper_format_write_string_cstr(file, "Preset", string_get_cstr(instance->preset_name))) break;
-        if(!flipper_format_write_uint32(file, "Frequency", &instance->frequency, 1)) break;
-        if(!flipper_format_write_uint32(file, "Hopping", &instance->hopping, 1)) break;
-        if(!flipper_format_write_uint32(file, "DetectRaw", &instance->detect_raw, 1)) break;
-        if(!flipper_format_write_int32(file, "Rssi", &instance->rssi_threshold, 1)) break;
+        if(!flipper_format_insert_or_update_string_cstr(file, "Preset", string_get_cstr(instance->preset_name))) break;
+        if(!flipper_format_insert_or_update_uint32(file, "Frequency", &instance->frequency, 1)) break;
+        if(!flipper_format_insert_or_update_uint32(file, "Hopping", &instance->hopping, 1)) break;
+        if(!flipper_format_insert_or_update_uint32(file, "DetectRaw", &instance->detect_raw, 1)) break;
+        if(!flipper_format_insert_or_update_int32(file, "Rssi", &instance->rssi_threshold, 1)) break;
 
         saved = true;
     } while(0);

--- a/applications/subghz/subghz_last_setting.h
+++ b/applications/subghz/subghz_last_setting.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <math.h>
+#include <furi.h>
+#include <furi_hal.h>
+#include <lib/flipper_format/flipper_format.h>
+
+typedef struct {
+    string_t preset_name;
+    uint32_t frequency;
+    uint32_t hopping;
+    uint32_t detect_raw;
+    int32_t rssi_threshold;
+} SubGhzLastSetting;
+
+SubGhzLastSetting* subghz_last_setting_alloc(void);
+
+void subghz_last_setting_free(SubGhzLastSetting* instance);
+
+void subghz_last_setting_load(SubGhzLastSetting* instance, const char* file_path);
+
+bool subghz_last_setting_save(SubGhzLastSetting* instance, const char* file_path);
+
+void subghz_last_setting_set_receiver_values(SubGhzLastSetting* instance, SubGhzReceiver* receiver);

--- a/applications/subghz/subghz_setting.c
+++ b/applications/subghz/subghz_setting.c
@@ -262,13 +262,7 @@ void subghz_setting_load(SubGhzSetting* instance, const char* file_path) {
                 break;
             }
             if(flipper_format_read_uint32(fff_data_file, "Default_frequency", &temp_data32, 1)) {
-                for
-                    M_EACH(frequency, instance->frequencies, FrequencyList_t) {
-                        *frequency &= FREQUENCY_MASK;
-                        if(*frequency == temp_data32) {
-                            *frequency |= FREQUENCY_FLAG_DEFAULT;
-                        }
-                    }
+                subghz_setting_set_default_frequency(instance, temp_data32);
             }
 
             // custom preset (optional)
@@ -293,6 +287,16 @@ void subghz_setting_load(SubGhzSetting* instance, const char* file_path) {
        !FrequencyList_size(instance->hopper_frequencies)) {
         FURI_LOG_E(TAG, "Error loading user settings, loading default settings");
         subghz_setting_load_default(instance);
+    }
+}
+
+void subghz_setting_set_default_frequency(SubGhzSetting* instance, uint32_t frequency_to_setup) {
+    for
+    M_EACH(frequency, instance->frequencies, FrequencyList_t) {
+        *frequency &= FREQUENCY_MASK;
+        if(*frequency == frequency_to_setup) {
+            *frequency |= FREQUENCY_FLAG_DEFAULT;
+        }
     }
 }
 

--- a/applications/subghz/subghz_setting.h
+++ b/applications/subghz/subghz_setting.h
@@ -46,3 +46,5 @@ uint32_t subghz_setting_get_hopper_frequency(SubGhzSetting* instance, size_t idx
 uint32_t subghz_setting_get_frequency_default_index(SubGhzSetting* instance);
 
 uint32_t subghz_setting_get_default_frequency(SubGhzSetting* instance);
+
+void subghz_setting_set_default_frequency(SubGhzSetting* instance, uint32_t frequency_to_setup);

--- a/assets/resources/subghz/assets/last_used.txt
+++ b/assets/resources/subghz/assets/last_used.txt
@@ -1,6 +1,0 @@
-Filetype: Flipper SubGhz Setting File
-Version: 1
-
-Frequency: 433920000
-Hopper_frequency: 433920000
-Preset: AM270

--- a/assets/resources/subghz/assets/last_used.txt
+++ b/assets/resources/subghz/assets/last_used.txt
@@ -1,0 +1,6 @@
+Filetype: Flipper SubGhz Setting File
+Version: 1
+
+Frequency: 433920000
+Hopper_frequency: 433920000
+Preset: AM270


### PR DESCRIPTION
# What's new

- Last used SubGHz settings in Read/ReadRAW are saving to separate file subghz/assets/last_used.txt
- Saving: Frequency, Modulation, Detect Raw, RSSI for Raw
- Settings file is created if missing

# Verification 

- Open SubGHz and go to Read or ReadRAW
- Go to Config and change settings
- Exit from SubGHz and open again SubGHz
- Changed settings at their places

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
