### PR TITLE
NameChanger Service

### DIFF
--- a/applications/services/application.fam
+++ b/applications/services/application.fam
@@ -10,5 +10,6 @@ App(
         "loader",
         "power",
 		"ibuttonsrv",
+        "namechangersrv",
     ],
 )

--- a/applications/services/namechangersrv/application.fam
+++ b/applications/services/namechangersrv/application.fam
@@ -1,0 +1,7 @@
+App(
+    appid="namechangersrv",
+    apptype=FlipperAppType.STARTUP,
+    entry_point="namechanger_on_system_start",
+    requires=["storage"],
+    order=130,
+)

--- a/applications/services/namechangersrv/namechangersrv.c
+++ b/applications/services/namechangersrv/namechangersrv.c
@@ -1,0 +1,178 @@
+#include "namechangersrv.h"
+#include "m-string.h"
+#include <toolbox/path.h>
+#include <flipper_format/flipper_format.h>
+
+void namechanger_on_system_start() {
+    Storage* storage = furi_record_open(RECORD_STORAGE);
+    FlipperFormat* file = flipper_format_file_alloc(storage);
+
+    string_t NAMEHEADER;
+    string_init_set_str(NAMEHEADER, "Flipper Name File");
+
+    string_t folderpath;
+    string_init_set_str(folderpath, "/ext/dolphin");
+
+    string_t filepath;
+    string_init_set_str(filepath, "/ext/dolphin/name.txt");
+
+    //Make dir if doesn't exist
+    if(storage_simply_mkdir(storage, string_get_cstr(folderpath))) {
+        bool result = false;
+
+        string_t data;
+        string_init(data);
+
+        do {
+            if(!flipper_format_file_open_existing(file, string_get_cstr(filepath))) {
+                break;
+            }
+
+            // header
+            uint32_t version;
+
+            if(!flipper_format_read_header(file, data, &version)) {
+                break;
+            }
+
+            if(string_cmp_str(data, string_get_cstr(NAMEHEADER)) != 0) {
+                break;
+            }
+
+            if(version != 1) {
+                break;
+            }
+
+            // get Name
+            if(!flipper_format_read_string(file, "Name", data)) {
+                break;
+            }
+
+            result = true;
+        } while(false);
+
+        flipper_format_free(file);
+
+        if(!result) {
+            //file not good - write new one
+            FlipperFormat* file = flipper_format_file_alloc(storage);
+
+            bool res = false;
+
+            string_t name;
+            string_init_set_str(name, furi_hal_version_get_name_ptr());
+
+            do {
+                // Open file for write
+                if(!flipper_format_file_open_always(file, string_get_cstr(filepath))) {
+                    break;
+                }
+
+                // Write header
+                if(!flipper_format_write_header_cstr(file, string_get_cstr(NAMEHEADER), 1)) {
+                    break;
+                }
+
+                // Write comments
+                if(!flipper_format_write_comment_cstr(
+                       file,
+                       "Changing the value below will change your FlipperZero device name.")) {
+                    break;
+                }
+
+                if(!flipper_format_write_comment_cstr(
+                       file,
+                       "Note: This is limited to 8 characters using the following: a-z, A-Z, 0-9, and _")) {
+                    break;
+                }
+
+                if(!flipper_format_write_comment_cstr(
+                       file, "It can contain other characters but use at your own risk.")) {
+                    break;
+                }
+
+                //Write name
+                if(!flipper_format_write_string_cstr(file, "Name", string_get_cstr(name))) {
+                    break;
+                }
+
+                res = true;
+            } while(false);
+
+            flipper_format_free(file);
+
+            if(!res) {
+                FURI_LOG_E(TAG, "Save failed.");
+            }
+
+            string_clear(name);
+        } else {
+            string_strim(data);
+            FURI_LOG_I(TAG, "data: %s", data);
+
+            if(!string_size(data)) {
+                //Empty file - get default name and write to file.
+                FlipperFormat* file = flipper_format_file_alloc(storage);
+
+                bool res = false;
+
+                string_t name;
+                string_init_set_str(name, furi_hal_version_get_name_ptr());
+
+                do {
+                    // Open file for write
+                    if(!flipper_format_file_open_always(file, string_get_cstr(filepath))) {
+                        break;
+                    }
+
+                    // Write header
+                    if(!flipper_format_write_header_cstr(file, string_get_cstr(NAMEHEADER), 1)) {
+                        break;
+                    }
+
+                    // Write comments
+                    if(!flipper_format_write_comment_cstr(
+                           file,
+                           "Changing the value below will change your FlipperZero device name.")) {
+                        break;
+                    }
+
+                    if(!flipper_format_write_comment_cstr(
+                           file,
+                           "Note: This is limited to 8 characters using the following: a-z, A-Z, 0-9, and _")) {
+                        break;
+                    }
+
+                    if(!flipper_format_write_comment_cstr(
+                           file, "It cannot contain any other characters.")) {
+                        break;
+                    }
+
+                    //Write name
+                    if(!flipper_format_write_string_cstr(file, "Name", string_get_cstr(name))) {
+                        break;
+                    }
+
+                    res = true;
+                } while(false);
+
+                flipper_format_free(file);
+
+                if(!res) {
+                    FURI_LOG_E(TAG, "Save failed.");
+                }
+
+                string_clear(name);
+            } else {
+                //set name from file
+                furi_hal_version_set_custom_name(string_get_cstr(data));
+            }
+        }
+
+        string_clear(data);
+    }
+
+    string_clear(filepath);
+    string_clear(folderpath);
+    furi_record_close(RECORD_STORAGE);
+}

--- a/applications/services/namechangersrv/namechangersrv.h
+++ b/applications/services/namechangersrv/namechangersrv.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <furi_hal.h>
+#include <storage/storage.h>
+
+#define NAMECHANGER_TEXT_STORE_SIZE 9
+#define NAMECHANGER_HEADER "Flipper Name File"
+
+#define TAG "NameChangerSRV"

--- a/firmware/targets/f7/api_symbols.csv
+++ b/firmware/targets/f7/api_symbols.csv
@@ -1,5 +1,5 @@
 entry,status,name,type,params
-Version,+,3.1,,
+Version,+,3.0,,
 Header,+,applications/services/bt/bt_service/bt.h,,
 Header,+,applications/services/cli/cli.h,,
 Header,+,applications/services/cli/cli_vcp.h,,

--- a/firmware/targets/f7/api_symbols.csv
+++ b/firmware/targets/f7/api_symbols.csv
@@ -1,5 +1,5 @@
 entry,status,name,type,params
-Version,+,3.0,,
+Version,+,3.1,,
 Header,+,applications/services/bt/bt_service/bt.h,,
 Header,+,applications/services/cli/cli.h,,
 Header,+,applications/services/cli/cli_vcp.h,,
@@ -1309,6 +1309,7 @@ Function,+,furi_hal_version_get_model_name,const char*,
 Function,+,furi_hal_version_get_name_ptr,const char*,
 Function,+,furi_hal_version_get_otp_version,FuriHalVersionOtpVersion,
 Function,-,furi_hal_version_init,void,
+Function,+,furi_hal_version_set_custom_name,void,const char*
 Function,+,furi_hal_version_uid,const uint8_t*,
 Function,+,furi_hal_version_uid_size,size_t,
 Function,-,furi_hal_vibro_init,void,

--- a/firmware/targets/f7/furi_hal/furi_hal_version.c
+++ b/firmware/targets/f7/furi_hal/furi_hal_version.c
@@ -90,6 +90,16 @@ typedef struct {
 
 static FuriHalVersion furi_hal_version = {0};
 
+void furi_hal_version_set_custom_name(const char* name) {
+    if((name != NULL) && ((strlen(name) >= 1) && (strlen(name) <= 8))) {
+        strlcpy(furi_hal_version.name, name, FURI_HAL_VERSION_ARRAY_NAME_LENGTH);
+        snprintf(
+            furi_hal_version.device_name, FURI_HAL_VERSION_DEVICE_NAME_LENGTH, "xFlipper %s", name);
+
+        furi_hal_version.device_name[0] = AD_TYPE_COMPLETE_LOCAL_NAME;
+    }
+}
+
 static void furi_hal_version_set_name(const char* name) {
     if(name != NULL) {
         strlcpy(furi_hal_version.name, name, FURI_HAL_VERSION_ARRAY_NAME_LENGTH);

--- a/firmware/targets/furi_hal_include/furi_hal_version.h
+++ b/firmware/targets/furi_hal_include/furi_hal_version.h
@@ -127,6 +127,9 @@ FuriHalVersionDisplay furi_hal_version_get_hw_display();
  */
 uint32_t furi_hal_version_get_hw_timestamp();
 
+// Set custom name
+void furi_hal_version_set_custom_name(const char* name);
+
 /** Get pointer to target name
  *
  * @return     Hardware Name C-string


### PR DESCRIPTION
## What's new

- At FlipperZero boot, `Name` is read from file and will be set like before.

## Verification 

#### With name.txt in dolphin folder
- Set and save `SD Card/dolphin/name.txt` file with a name that is a maximum of 8 characters.
- Reboot FlipperZero.
- FZ should read `Name` in file and sets the device's name accordingly.
- If `Name` is blank, no name is changed, and current name is written to file.

#### Without name.txt in dolphin folder
- Delete `SD Card/dolphin/name.txt` file
- Reboot FlipperZero.
- At boot, FlipperZero will create a new name.txt file with the current name.

### Notes
- As before, this will overwrite Default Name or `CUSTOM_FLIPPER_NAME` for Passport and USB but not Bluetooth.
- Default Name or `CUSTOM_FLIPPER_NAME` is restored if name.txt is deleted or `Name` is blank/NULL and FlipperZero is restarted.

- After flashing completed and I clicked through the splash screens, I experienced an instant `NULL dereference pointer` crash. This happened once or twice during testing of other things so I'm not sure if it was NameChangerSrv or if it was something else.
- NameChanger app is not included as it continuously crashes on me.

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
