### PR TITLE
[IdleShutdown] Don't reload the settings every second

### DIFF
--- a/applications/services/power/power_service/power.c
+++ b/applications/services/power/power_service/power.c
@@ -127,22 +127,6 @@ static void power_auto_shutdown_timer_callback(void* context) {
     power_off(power);
 }
 
-static void auto_shutdown_update(Power* power) {
-    uint32_t old_time = power->shutdown_idle_delay_ms;
-    LOAD_POWER_SETTINGS(&power->shutdown_idle_delay_ms);
-    if(power->shutdown_idle_delay_ms) {
-        if(power->shutdown_idle_delay_ms != old_time) {
-            if(old_time) {
-                power_start_auto_shutdown_timer(power);
-            } else {
-                power_auto_shutdown_arm(power);
-            }
-        }
-    } else if(old_time) {
-        power_auto_shutdown_inhibit(power);
-    }
-}
-
 Power* power_alloc() {
     Power* power = malloc(sizeof(Power));
 
@@ -338,9 +322,6 @@ int32_t power_srv(void* p) {
     free(settings);
 
     while(1) {
-        //Check current setting for automatic shutdown
-        auto_shutdown_update(power);
-
         // Update data from gauge and charger
         bool need_refresh = power_update_info(power);
 

--- a/applications/settings/power_settings_app/scenes/power_settings_scene_shutdown_idle.c
+++ b/applications/settings/power_settings_app/scenes/power_settings_scene_shutdown_idle.c
@@ -10,6 +10,8 @@ const char* const shutdown_idle_delay_text[SHUTDOWN_IDLE_DELAY_COUNT] =
 const uint32_t shutdown_idle_delay_value[SHUTDOWN_IDLE_DELAY_COUNT] =
     {0, 900000, 1800000, 3600000, 21600000, 43200000, 86400000, 172800000};
 
+uint32_t origShutdownIdleDelay_value = 0;
+
 static void power_settings_scene_shutodwn_idle_callback(void* context, uint32_t index) {
     PowerSettingsApp* app = context;
     view_dispatcher_send_custom_event(app->view_dispatcher, index);
@@ -29,6 +31,7 @@ void power_settings_scene_shutdown_idle_on_enter(void* context) {
     VariableItemList* variable_item_list = app->variable_item_list;
     VariableItem* item;
     uint8_t value_index;
+    origShutdownIdleDelay_value = app->shutdown_idle_delay_ms;
 
     item = variable_item_list_add(
         variable_item_list,
@@ -64,4 +67,8 @@ void power_settings_scene_shutdown_idle_on_exit(void* context) {
     PowerSettingsApp* app = context;
     SAVE_POWER_SETTINGS(&app->shutdown_idle_delay_ms);
     variable_item_list_reset(app->variable_item_list);
+
+    if(app->shutdown_idle_delay_ms != origShutdownIdleDelay_value) {
+        furi_hal_power_reset();
+    }
 }


### PR DESCRIPTION
# What's new

The current implementation of the "Shutdown on Idle" features reloads the power settings file every second to check for changes in the settings. (The `auto_shutdown_update()` [is called inside the main power service loop](https://github.com/RogueMaster/flipperzero-firmware-wPlugins/blob/e631285ff3620c06a68db0aaddab1fd065b3a13a/applications/services/power/power_service/power.c#L342)). This behaviour is also verifiable by checking the logs from the serial console, since they get spammed by `[I][SavedStruct] Loading "/int/.power.settings"`messages.    

This behavior is wasteful and could be detrimental on the internal memory. The simplest solution to fix this (implemented here) is to just reboot the Flipper when the setting is changed from the menu, i.e. the same thing that happens when the battery style is changed. The Flipper will just reload the new config on the next boot and no continuous checks are needed.    

# Verification 

Monitor the logs from the serial console to verify that the Loading calls are no more being spammed every second.

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
