### PR TITLE
Snake: Allow food to spawn anywhere

### DIFF
--- a/applications/plugins/snake_game/snake_game.c
+++ b/applications/plugins/snake_game/snake_game.c
@@ -196,8 +196,8 @@ static Point snake_game_get_new_fruit(SnakeState const* const snake_state) {
             if((buffer[y] & mask) == 0) {
                 if(newFruit == 0) {
                     Point p = {
-                        .x = x * 2,
-                        .y = y * 2,
+                        .x = x,
+                        .y = y,
                     };
                     return p;
                 }


### PR DESCRIPTION
food was only spawning on old snake path from previous firmware versions, now it can spawn on each pixel on new snake path

# What's new

- [ Describe changes here ]

# Verification 

- [ Describe how to verify changes ]

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
