### PR TITLE
[v2] Fixed issues when loading iButton keys or U2F token from Archive app

### DIFF
--- a/applications/main/archive/scenes/archive_scene_browser.c
+++ b/applications/main/archive/scenes/archive_scene_browser.c
@@ -45,10 +45,31 @@ static void archive_run_in_app(ArchiveBrowserView* browser, ArchiveFile_t* selec
         if(param != NULL) {
             param++;
         }
-        status = loader_start(loader, flipper_app_name[selected->type], param);
+
+        if(strcmp(flipper_app_name[selected->type], "U2F") == 0) {
+            char* tmpType = "/ext/apps/Main/U2F.fap¯";
+            char* result =
+                malloc(strlen(tmpType) + strlen(furi_string_get_cstr(selected->path)) + 1);
+
+            strcpy(result, tmpType);
+            strcat(result, furi_string_get_cstr(selected->path));
+            status = loader_start(loader, "Applications", result);
+        } else {
+            status = loader_start(loader, flipper_app_name[selected->type], param);
+        }
     } else {
-        status = loader_start(
-            loader, flipper_app_name[selected->type], furi_string_get_cstr(selected->path));
+        if(strcmp(flipper_app_name[selected->type], "iButton") == 0) {
+            char* tmpType = "/ext/apps/Main/ibutton.fap¯";
+            char* result =
+                malloc(strlen(tmpType) + strlen(furi_string_get_cstr(selected->path)) + 1);
+
+            strcpy(result, tmpType);
+            strcat(result, furi_string_get_cstr(selected->path));
+            status = loader_start(loader, "Applications", result);
+        } else {
+            status = loader_start(
+                loader, flipper_app_name[selected->type], furi_string_get_cstr(selected->path));
+        }
     }
 
     if(status != LoaderStatusOk) {

--- a/applications/main/fap_loader/fap_loader_app.c
+++ b/applications/main/fap_loader/fap_loader_app.c
@@ -16,6 +16,7 @@ struct FapLoader {
     DialogsApp* dialogs;
     Gui* gui;
     FuriString* fap_path;
+    FuriString* fap_args;
     ViewDispatcher* view_dispatcher;
     Loading* loading;
 };
@@ -102,15 +103,31 @@ static bool fap_loader_run_selected_app(FapLoader* loader) {
 
         FURI_LOG_I(TAG, "Loaded in %ums", (size_t)(furi_get_tick() - start));
         FURI_LOG_I(TAG, "FAP Loader is starting app");
+		
+		if(strcmp(furi_string_get_cstr(loader->fap_args), "false") == 0)
+		{
+			FuriThread* thread =
+				flipper_application_spawn(loader->app, NULL);
+			furi_thread_start(thread);
+			furi_thread_join(thread);
 
-        FuriThread* thread = flipper_application_spawn(loader->app, NULL);
-        furi_thread_start(thread);
-        furi_thread_join(thread);
+			show_error = false;
+			int ret = furi_thread_get_return_code(thread);
 
-        show_error = false;
-        int ret = furi_thread_get_return_code(thread);
+			FURI_LOG_I(TAG, "FAP app returned: %i", ret);
+		}
+		else
+		{
+			FuriThread* thread =
+				flipper_application_spawn(loader->app, (void*)furi_string_get_cstr(loader->fap_args));
+			furi_thread_start(thread);
+			furi_thread_join(thread);
 
-        FURI_LOG_I(TAG, "FAP app returned: %i", ret);
+			show_error = false;
+			int ret = furi_thread_get_return_code(thread);
+
+			FURI_LOG_I(TAG, "FAP app returned: %i", ret);
+		}
     } while(0);
 
     if(show_error) {
@@ -155,7 +172,27 @@ static bool fap_loader_select_app(FapLoader* loader) {
 
 static FapLoader* fap_loader_alloc(const char* path) {
     FapLoader* loader = malloc(sizeof(FapLoader));
-    loader->fap_path = furi_string_alloc_set(path);
+
+    char* tmp = malloc(strlen(path) + 1);
+    strcpy(tmp, path);
+    char* new_path;
+
+    new_path = strtok(tmp, "¯");
+
+    if(new_path) {
+        loader->fap_path = furi_string_alloc_set(new_path);
+    } else {
+        loader->fap_path = furi_string_alloc_set(path);
+    }
+
+    new_path = strtok(NULL, "¯");
+
+    if(new_path) {
+        loader->fap_args = furi_string_alloc_set(new_path);
+    } else {
+        loader->fap_args = furi_string_alloc_set("false");
+    }
+
     loader->storage = furi_record_open(RECORD_STORAGE);
     loader->dialogs = furi_record_open(RECORD_DIALOGS);
     loader->gui = furi_record_open(RECORD_GUI);
@@ -172,6 +209,7 @@ static void fap_loader_free(FapLoader* loader) {
     loading_free(loader->loading);
     view_dispatcher_free(loader->view_dispatcher);
     furi_string_free(loader->fap_path);
+    furi_string_free(loader->fap_args);
     furi_record_close(RECORD_GUI);
     furi_record_close(RECORD_DIALOGS);
     furi_record_close(RECORD_STORAGE);


### PR DESCRIPTION
### What's new

- Fixed an issue when loading iButton keys from Archive app either as a pinned Favorite or selecting a file in the iButton section.
- Fixed an issue when loading U2F token from Archive app either as a pinned Favorite or selecting a file in the U2F section.

### Verification 
#### Test 1 - iButton key select from iButton section:
- Open Archive app
- Select a key file from iButton section
- Select `Run in App`
- iButton FAP should load, and selected key file should automatically be running

#### Test 2 - iButton key select from Favorites section:
- Open Archive app
- Select a key file from iButton section
- Select `Pin`
- Close and reopen Archive app
- Select iButton key file from Favorites section
- iButton FAP should load, and selected key file should automatically be running

### Notes
- Verification steps can be repeated to test U2F token but I don't have a valid token to test at the moment

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
