### PR TITLE
Fixed boot loop during updating

### DIFF
--- a/applications/services/desktop/desktop.c
+++ b/applications/services/desktop/desktop.c
@@ -326,45 +326,53 @@ static bool desktop_check_file_flag(const char* flag_path) {
 
 int32_t desktop_srv(void* p) {
     UNUSED(p);
-    Desktop* desktop = desktop_alloc();
-
-    bool loaded = DESKTOP_SETTINGS_LOAD(&desktop->settings);
-    if(!loaded) {
-        memset(&desktop->settings, 0, sizeof(desktop->settings));
-        DESKTOP_SETTINGS_SAVE(&desktop->settings);
+	
+	if(furi_hal_rtc_get_boot_mode() != FuriHalRtcBootModeNormal)
+	{
+		FURI_LOG_W("Desktop", "Desktop load skipped. Device is in special startup mode.");
     }
+	else
+	{
+		Desktop* desktop = desktop_alloc();
 
-    view_port_enabled_set(desktop->dummy_mode_icon_viewport, desktop->settings.dummy_mode);
-    desktop_main_set_dummy_mode_state(desktop->main_view, desktop->settings.dummy_mode);
-    animation_manager_set_dummy_mode_state(
-        desktop->animation_manager, desktop->settings.dummy_mode);
+		bool loaded = DESKTOP_SETTINGS_LOAD(&desktop->settings);
+		if(!loaded) {
+			memset(&desktop->settings, 0, sizeof(desktop->settings));
+			DESKTOP_SETTINGS_SAVE(&desktop->settings);
+		}
 
-    scene_manager_next_scene(desktop->scene_manager, DesktopSceneMain);
+		view_port_enabled_set(desktop->dummy_mode_icon_viewport, desktop->settings.dummy_mode);
+		desktop_main_set_dummy_mode_state(desktop->main_view, desktop->settings.dummy_mode);
+		animation_manager_set_dummy_mode_state(
+			desktop->animation_manager, desktop->settings.dummy_mode);
 
-    desktop_pin_lock_init(&desktop->settings);
+		scene_manager_next_scene(desktop->scene_manager, DesktopSceneMain);
 
-    if(!desktop_pin_lock_is_locked()) {
-        if(!loader_is_locked(desktop->loader)) {
-            desktop_auto_lock_arm(desktop);
-        }
-    } else {
-        desktop_lock(desktop);
-    }
+		desktop_pin_lock_init(&desktop->settings);
 
-    if(desktop_check_file_flag(SLIDESHOW_FS_PATH)) {
-        scene_manager_next_scene(desktop->scene_manager, DesktopSceneSlideshow);
-    }
+		if(!desktop_pin_lock_is_locked()) {
+			if(!loader_is_locked(desktop->loader)) {
+				desktop_auto_lock_arm(desktop);
+			}
+		} else {
+			desktop_lock(desktop);
+		}
 
-    if(!furi_hal_version_do_i_belong_here()) {
-        scene_manager_next_scene(desktop->scene_manager, DesktopSceneHwMismatch);
-    }
+		if(desktop_check_file_flag(SLIDESHOW_FS_PATH)) {
+			scene_manager_next_scene(desktop->scene_manager, DesktopSceneSlideshow);
+		}
 
-    if(furi_hal_rtc_get_fault_data()) {
-        scene_manager_next_scene(desktop->scene_manager, DesktopSceneFault);
-    }
+		if(!furi_hal_version_do_i_belong_here()) {
+			scene_manager_next_scene(desktop->scene_manager, DesktopSceneHwMismatch);
+		}
 
-    view_dispatcher_run(desktop->view_dispatcher);
-    desktop_free(desktop);
+		if(furi_hal_rtc_get_fault_data()) {
+			scene_manager_next_scene(desktop->scene_manager, DesktopSceneFault);
+		}
+
+		view_dispatcher_run(desktop->view_dispatcher);
+		desktop_free(desktop);
+	}
 
     return 0;
 }

--- a/applications/services/namechangersrv/namechangersrv.c
+++ b/applications/services/namechangersrv/namechangersrv.c
@@ -4,157 +4,166 @@
 #include <flipper_format/flipper_format.h>
 
 void namechanger_on_system_start() {
-    Storage* storage = furi_record_open(RECORD_STORAGE);
-    FlipperFormat* file = flipper_format_file_alloc(storage);
-
-    FuriString* NAMEHEADER;
-    NAMEHEADER = furi_string_alloc_set("Flipper Name File");
-
-    FuriString* filepath;
-    filepath = furi_string_alloc_set("/ext/dolphin/name.txt");
-
-    bool result = false;
-
-    FuriString* data;
-    data = furi_string_alloc();
-
-    do {
-        if(!flipper_format_file_open_existing(file, furi_string_get_cstr(filepath))) {
-            break;
-        }
-
-        // header
-        uint32_t version;
-
-        if(!flipper_format_read_header(file, data, &version)) {
-            break;
-        }
-
-        if(furi_string_cmp_str(data, furi_string_get_cstr(NAMEHEADER)) != 0) {
-            break;
-        }
-
-        if(version != 1) {
-            break;
-        }
-
-        // get Name
-        if(!flipper_format_read_string(file, "Name", data)) {
-            break;
-        }
-
-        result = true;
-    } while(false);
-
-    flipper_format_free(file);
-
-    if(!result) {
-        //file not good - write new one
-        FlipperFormat* file = flipper_format_file_alloc(storage);
-
-        bool res = false;
-
-        do {
-            // Open file for write
-            if(!flipper_format_file_open_always(file, furi_string_get_cstr(filepath))) {
-                break;
-            }
-
-            // Write header
-            if(!flipper_format_write_header_cstr(file, furi_string_get_cstr(NAMEHEADER), 1)) {
-                break;
-            }
-
-            // Write comments
-            if(!flipper_format_write_comment_cstr(
-                   file, "Changing the value below will change your FlipperZero device name.")) {
-                break;
-            }
-
-            if(!flipper_format_write_comment_cstr(
-                   file,
-                   "Note: This is limited to 8 characters using the following: a-z, A-Z, 0-9, and _")) {
-                break;
-            }
-
-            if(!flipper_format_write_comment_cstr(
-                   file, "It can contain other characters but use at your own risk.")) {
-                break;
-            }
-
-            //Write name
-            if(!flipper_format_write_string_cstr(file, "Name", furi_hal_version_get_name_ptr())) {
-                break;
-            }
-
-            res = true;
-        } while(false);
-
-        flipper_format_free(file);
-
-        if(!res) {
-            FURI_LOG_E(TAG, "Save failed.");
-        }
-    } else {
-        if(!furi_string_size(data)) {
-            //Empty file - get default name and write to file.
-            FlipperFormat* file = flipper_format_file_alloc(storage);
-
-            bool res = false;
-
-            do {
-                // Open file for write
-                if(!flipper_format_file_open_always(file, furi_string_get_cstr(filepath))) {
-                    break;
-                }
-
-                // Write header
-                if(!flipper_format_write_header_cstr(file, furi_string_get_cstr(NAMEHEADER), 1)) {
-                    break;
-                }
-
-                // Write comments
-                if(!flipper_format_write_comment_cstr(
-                       file,
-                       "Changing the value below will change your FlipperZero device name.")) {
-                    break;
-                }
-
-                if(!flipper_format_write_comment_cstr(
-                       file,
-                       "Note: This is limited to 8 characters using the following: a-z, A-Z, 0-9, and _")) {
-                    break;
-                }
-
-                if(!flipper_format_write_comment_cstr(
-                       file, "It cannot contain any other characters.")) {
-                    break;
-                }
-
-                //Write name
-                if(!flipper_format_write_string_cstr(
-                       file, "Name", furi_hal_version_get_name_ptr())) {
-                    break;
-                }
-
-                res = true;
-            } while(false);
-
-            flipper_format_free(file);
-
-            if(!res) {
-                FURI_LOG_E(TAG, "Save failed.");
-            }
-        } else {
-            char newdata[9];
-            snprintf(newdata, 9, "%s", furi_string_get_cstr(data));
-            //set name from file
-            furi_hal_version_set_custom_name(newdata);
-        }
+	if(furi_hal_rtc_get_boot_mode() != FuriHalRtcBootModeNormal)
+	{
+		FURI_LOG_W(TAG, "NameChangerSRV load skipped. Device is in special startup mode.");
     }
+	else
+	{
+		Storage* storage = furi_record_open(RECORD_STORAGE);
+		FlipperFormat* file = flipper_format_file_alloc(storage);
 
-    furi_string_free(data);
+		FuriString* NAMEHEADER;
+		NAMEHEADER = furi_string_alloc_set("Flipper Name File");
 
-    furi_string_free(filepath);
-    furi_record_close(RECORD_STORAGE);
+		FuriString* filepath;
+		filepath = furi_string_alloc_set("/ext/dolphin/name.txt");
+
+		bool result = false;
+		
+		FuriString* data;
+		data = furi_string_alloc();
+		
+		do {
+			if(!flipper_format_file_open_existing(file, furi_string_get_cstr(filepath))) {
+				break;
+			}
+			
+			// header
+			uint32_t version;
+			
+			if(!flipper_format_read_header(file, data, &version)) {
+				break;
+			}
+			
+			if(furi_string_cmp_str(data, furi_string_get_cstr(NAMEHEADER)) != 0) {
+				break;
+			}
+			
+			if(version != 1) {
+				break;
+			}
+			
+			// get Name
+			if(!flipper_format_read_string(file, "Name", data)) {
+				break;
+			}
+			
+			result = true;
+		} while(false);
+		
+		flipper_format_free(file);
+		
+		if(!result) {
+			//file not good - write new one
+			FlipperFormat* file = flipper_format_file_alloc(storage);
+
+			bool res = false;
+
+			do {
+				// Open file for write
+				if(!flipper_format_file_open_always(file, furi_string_get_cstr(filepath))) {
+					break;
+				}
+
+				// Write header
+				if(!flipper_format_write_header_cstr(file, furi_string_get_cstr(NAMEHEADER), 1)) {
+					break;
+				}
+
+				// Write comments
+				if(!flipper_format_write_comment_cstr(
+					   file,
+					   "Changing the value below will change your FlipperZero device name.")) {
+					break;
+				}
+
+				if(!flipper_format_write_comment_cstr(
+					   file,
+					   "Note: This is limited to 8 characters using the following: a-z, A-Z, 0-9, and _")) {
+					break;
+				}
+
+				if(!flipper_format_write_comment_cstr(
+					   file, "It can contain other characters but use at your own risk.")) {
+					break;
+				}
+
+				//Write name
+				if(!flipper_format_write_string_cstr(file, "Name", furi_hal_version_get_name_ptr())) {
+					break;
+				}
+
+				res = true;
+			} while(false);
+
+			flipper_format_free(file);
+
+			if(!res) {
+				FURI_LOG_E(TAG, "Save failed.");
+			}
+		} else {
+			if(!furi_string_size(data)) {
+				//Empty file - get default name and write to file.
+				FlipperFormat* file = flipper_format_file_alloc(storage);
+
+				bool res = false;
+
+				do {
+					// Open file for write
+					if(!flipper_format_file_open_always(file, furi_string_get_cstr(filepath))) {
+						break;
+					}
+
+					// Write header
+					if(!flipper_format_write_header_cstr(
+						   file, furi_string_get_cstr(NAMEHEADER), 1)) {
+						break;
+					}
+
+					// Write comments
+					if(!flipper_format_write_comment_cstr(
+						   file,
+						   "Changing the value below will change your FlipperZero device name.")) {
+						break;
+					}
+
+					if(!flipper_format_write_comment_cstr(
+						   file,
+						   "Note: This is limited to 8 characters using the following: a-z, A-Z, 0-9, and _")) {
+						break;
+					}
+
+					if(!flipper_format_write_comment_cstr(
+						   file, "It cannot contain any other characters.")) {
+						break;
+					}
+
+					//Write name
+					if(!flipper_format_write_string_cstr(
+						   file, "Name", furi_hal_version_get_name_ptr())) {
+						break;
+					}
+
+					res = true;
+				} while(false);
+
+				flipper_format_free(file);
+
+				if(!res) {
+					FURI_LOG_E(TAG, "Save failed.");
+				}
+			} else {
+				char newdata[9];
+				snprintf(newdata, 9, "%s", furi_string_get_cstr(data));
+				//set name from file
+				furi_hal_version_set_custom_name(newdata);
+			}
+		}
+		
+		furi_string_free(data);
+
+		furi_string_free(filepath);
+		furi_record_close(RECORD_STORAGE);
+	}
 }


### PR DESCRIPTION
Made NameChanger Service and Desktop Service not load if RTCBootMode wasn't in a normal state (aka when updating)

Boot loop issue occurs when AnimationManager (Desktop) tries to load an invalid animation during the update process. The animation list used when trying to load is the newly updated manifest file but the resources haven't been uploaded to the SD card yet.