### PR TITLE
remove touchtunes brute map

### DIFF
--- a/assets/resources/subghz/unirf/touchtunes_brute_map.txt
+++ b/assets/resources/subghz/unirf/touchtunes_brute_map.txt
@@ -1,7 +1,0 @@
-Filetype: Flipper SubGhz RAW File
-Version: 1
-UP: /any/subghz/TouchTunes/brute/P2_Edit_Queue.sub
-DOWN: /any/subghz/TouchTunes/brute/Pause.sub
-LEFT: /any/subghz/TouchTunes/brute/On_Off.sub
-RIGHT: /any/subghz/TouchTunes/brute/P1.sub
-OK: /any/subghz/TouchTunes/brute/OK.sub


### PR DESCRIPTION
# What's new

Removes the `touchtunes_brute_map.txt` file since the Touch Tunes .sub files aren't included in the firmware thus making this file useless.

# Verification 

Go to the sub-ghz remote, make sure `trouchtunes_brute_map` is no longer there

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
