### PR TITLE
LED Pulser: Replace ValueMutex with FuriMutex

### DIFF
--- a/applications/plugins/ledpulser/ledpulser.c
+++ b/applications/plugins/ledpulser/ledpulser.c
@@ -18,16 +18,13 @@ typedef struct {
     int color;
     int intensity;
     int direction;
-    FuriMutex* mutex;
 } PluginState;
 
 int intensity = 0;
 
 void led_test_draw_callback(Canvas* canvas, void* ctx) {
-    //UNUSED(ctx);
     furi_assert(ctx);
     PluginState* plugin_state = ctx;
-    furi_mutex_acquire(plugin_state->mutex, FuriWaitForever);
 
     canvas_clear(canvas);
     canvas_set_font(canvas, FontSecondary);
@@ -67,7 +64,6 @@ void led_test_draw_callback(Canvas* canvas, void* ctx) {
         canvas_draw_str(canvas, 49, 35, "White");
         canvas_invert_color(canvas);
     }
-    furi_mutex_release(plugin_state->mutex);
 }
 
 void led_test_input_callback(InputEvent* input_event, void* ctx) {
@@ -98,14 +94,13 @@ int32_t ledpulser_app(void* p) {
     FuriMessageQueue* event_queue = furi_message_queue_alloc(8, sizeof(InputEvent));
 
     PluginState* plugin_state = malloc(sizeof(PluginState));
-    NotificationMessage* dyn_notification_message = malloc(sizeof(NotificationMessage));
-    plugin_state->mutex = furi_mutex_alloc(FuriMutexTypeNormal);
-    if(!plugin_state->mutex) {
-        FURI_LOG_E("LED Pulser", "cannot create mutex\r\n");
-        free(plugin_state);
-        free(dyn_notification_message);
+    FuriMutex* state_mutex;
+    state_mutex = furi_mutex_alloc(FuriMutexTypeNormal);
+    if(!state_mutex) {
+        FURI_LOG_E("LED Pulser", "cannot create mutex");
         return 255;
     }
+    
     plugin_state->direction = 0;
     plugin_state->intensity = 0;
     DOLPHIN_DEED(DolphinDeedPluginStart);
@@ -126,7 +121,9 @@ int32_t ledpulser_app(void* p) {
     notification_message(notification, &sequence_display_backlight_on);
     while(processing) {
         FuriStatus event_status = furi_message_queue_get(event_queue, &event, 100);
-        furi_mutex_acquire(plugin_state->mutex, FuriWaitForever);
+        //PluginState* plugin_state = (PluginState*)acquire_mutex_block(&state_mutex);
+        furi_mutex_acquire(state_mutex, FuriWaitForever);
+
         NotificationMessage notification_led_message;
         NotificationMessage notification_led_message_1;
         NotificationMessage notification_led_message_2;
@@ -247,14 +244,15 @@ int32_t ledpulser_app(void* p) {
                 }
             }
         }
-        furi_mutex_release(plugin_state->mutex);
+        furi_mutex_release(state_mutex);
     }
     gui_remove_view_port(gui, view_port);
     view_port_free(view_port);
-    furi_mutex_free(plugin_state->mutex);
     furi_message_queue_free(event_queue);
+
     furi_record_close(RECORD_NOTIFICATION);
     furi_record_close(RECORD_GUI);
-    free(plugin_state);
+    furi_mutex_free(state_mutex);
+
     return 0;
 }


### PR DESCRIPTION
# What's new

- LED Pulser, replaced ValueMutex with FuriMutex for compatibility with FW 0.79+

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
