### PR TITLE
Another slight update to remove unneeded code

### DIFF
--- a/applications/services/desktop/desktop_i.h
+++ b/applications/services/desktop/desktop_i.h
@@ -65,14 +65,12 @@ struct Desktop {
     ViewPort* topbar_icon_viewport;
     ViewPort* sdcard_icon_viewport;
     ViewPort* bt_icon_viewport;
-    ViewPort* rpc_icon_viewport;
 
     ViewPort* lock_icon_slim_viewport;
     ViewPort* dummy_mode_icon_slim_viewport;
     ViewPort* topbar_icon_slim_viewport;
     ViewPort* sdcard_icon_slim_viewport;
     ViewPort* bt_icon_slim_viewport;
-    ViewPort* rpc_icon_slim_viewport;
 
     AnimationManager* animation_manager;
 


### PR DESCRIPTION
Found another two lines that aren't required for RPC icon that I forgot to remove.

Note: The icon is being drawn from the rpc service, I thought I had to do a workaround fix like I did with BT and SD card icons but turns out that it wasn't required
