### PR TITLE
Desktop Settings Update - No more reboot needed

### DIFF
--- a/applications/services/desktop/desktop.c
+++ b/applications/services/desktop/desktop.c
@@ -92,6 +92,7 @@ static void desktop_bt_connection_status_update_icon(BtStatus status, void* cont
                 desktop->bt_icon_slim_viewport, icon_get_width(&I_Bluetooth_Idle_5x8));
             view_port_draw_callback_set(
                 desktop->bt_icon_slim_viewport, desktop_bt_icon_draw_idle_callback, desktop);
+            view_port_enabled_set(desktop->bt_icon_viewport, false);
             view_port_enabled_set(desktop->bt_icon_slim_viewport, desktop->settings.bt_icon);
             view_port_update(desktop->bt_icon_slim_viewport);
             break;
@@ -100,6 +101,7 @@ static void desktop_bt_connection_status_update_icon(BtStatus status, void* cont
             view_port_draw_callback_set(
                 desktop->bt_icon_viewport, desktop_bt_icon_draw_idle_callback, desktop);
             view_port_enabled_set(desktop->bt_icon_viewport, desktop->settings.bt_icon);
+            view_port_enabled_set(desktop->bt_icon_slim_viewport, false);
             view_port_update(desktop->bt_icon_viewport);
             break;
         }
@@ -110,6 +112,7 @@ static void desktop_bt_connection_status_update_icon(BtStatus status, void* cont
                 desktop->bt_icon_slim_viewport, icon_get_width(&I_Bluetooth_Connected_16x8));
             view_port_draw_callback_set(
                 desktop->bt_icon_slim_viewport, desktop_bt_icon_draw_connected_callback, desktop);
+            view_port_enabled_set(desktop->bt_icon_viewport, false);
             view_port_enabled_set(desktop->bt_icon_slim_viewport, desktop->settings.bt_icon);
             view_port_update(desktop->bt_icon_slim_viewport);
             break;
@@ -119,6 +122,7 @@ static void desktop_bt_connection_status_update_icon(BtStatus status, void* cont
             view_port_draw_callback_set(
                 desktop->bt_icon_viewport, desktop_bt_icon_draw_connected_callback, desktop);
             view_port_enabled_set(desktop->bt_icon_viewport, desktop->settings.bt_icon);
+            view_port_enabled_set(desktop->bt_icon_slim_viewport, false);
             view_port_update(desktop->bt_icon_viewport);
             break;
         }
@@ -199,6 +203,47 @@ static void desktop_tick_event_callback(void* context) {
     if(desktop->settings.bt_icon) {
         BtStatus status = bt_get_status(desktop->bt);
         desktop_bt_connection_status_update_icon(status, desktop);
+    } else {
+        view_port_enabled_set(desktop->bt_icon_viewport, false);
+        view_port_enabled_set(desktop->bt_icon_slim_viewport, false);
+    }
+
+    view_port_enabled_set(desktop->topbar_icon_viewport, desktop->settings.top_bar);
+
+    switch(desktop->settings.icon_style) {
+    case ICON_STYLE_SLIM:
+        //dummy mode icon
+        if(desktop->settings.dumbmode_icon) {
+            view_port_enabled_set(desktop->dummy_mode_icon_viewport, false);
+            view_port_enabled_set(
+                desktop->dummy_mode_icon_slim_viewport, desktop->settings.dummy_mode);
+        }
+        //stealth icon
+        if(furi_hal_rtc_is_flag_set(FuriHalRtcFlagStealthMode)) {
+            view_port_enabled_set(desktop->stealth_mode_icon_viewport, false);
+            view_port_enabled_set(
+                desktop->stealth_mode_icon_slim_viewport, desktop->settings.stealth_icon);
+        }
+        //sdcard icon
+        view_port_enabled_set(desktop->sdcard_icon_viewport, false);
+        view_port_enabled_set(desktop->sdcard_icon_slim_viewport, desktop->settings.sdcard);
+        break;
+    case ICON_STYLE_STOCK:
+        //dummy mode icon
+        if(desktop->settings.dumbmode_icon) {
+            view_port_enabled_set(desktop->dummy_mode_icon_viewport, desktop->settings.dummy_mode);
+            view_port_enabled_set(desktop->dummy_mode_icon_slim_viewport, false);
+        }
+        //stealth icon
+        if(furi_hal_rtc_is_flag_set(FuriHalRtcFlagStealthMode)) {
+            view_port_enabled_set(
+                desktop->stealth_mode_icon_viewport, desktop->settings.stealth_icon);
+            view_port_enabled_set(desktop->stealth_mode_icon_slim_viewport, false);
+        }
+        //sdcard icon
+        view_port_enabled_set(desktop->sdcard_icon_viewport, desktop->settings.sdcard);
+        view_port_enabled_set(desktop->sdcard_icon_slim_viewport, false);
+        break;
     }
 
     scene_manager_handle_tick_event(desktop->scene_manager);
@@ -532,7 +577,6 @@ void desktop_free(Desktop* desktop) {
 
     free(desktop->lock_icon_slim_viewport);
     free(desktop->dummy_mode_icon_slim_viewport);
-    free(desktop->topbar_icon_slim_viewport);
     free(desktop->sdcard_icon_slim_viewport);
     free(desktop->bt_icon_slim_viewport);
     free(desktop->stealth_mode_icon_slim_viewport);
@@ -615,26 +659,44 @@ int32_t desktop_srv(void* p) {
 
         switch(desktop->settings.icon_style) {
         case ICON_STYLE_SLIM:
-            view_port_enabled_set(desktop->sdcard_icon_slim_viewport, desktop->settings.sdcard);
+            //dummy mode icon
             if(desktop->settings.dumbmode_icon) {
+                view_port_enabled_set(desktop->dummy_mode_icon_viewport, false);
                 view_port_enabled_set(
                     desktop->dummy_mode_icon_slim_viewport, desktop->settings.dummy_mode);
             }
+            //stealth icon
             if(furi_hal_rtc_is_flag_set(FuriHalRtcFlagStealthMode)) {
+                view_port_enabled_set(desktop->stealth_mode_icon_viewport, false);
                 view_port_enabled_set(
                     desktop->stealth_mode_icon_slim_viewport, desktop->settings.stealth_icon);
             }
+            //sdcard icon
+            view_port_enabled_set(desktop->sdcard_icon_viewport, false);
+            view_port_enabled_set(desktop->sdcard_icon_slim_viewport, desktop->settings.sdcard);
+            //bt icon
+            view_port_enabled_set(desktop->bt_icon_viewport, false);
+            view_port_enabled_set(desktop->bt_icon_slim_viewport, desktop->settings.bt_icon);
             break;
         case ICON_STYLE_STOCK:
-            view_port_enabled_set(desktop->sdcard_icon_viewport, desktop->settings.sdcard);
+            //dummy mode icon
             if(desktop->settings.dumbmode_icon) {
                 view_port_enabled_set(
                     desktop->dummy_mode_icon_viewport, desktop->settings.dummy_mode);
+                view_port_enabled_set(desktop->dummy_mode_icon_slim_viewport, false);
             }
+            //stealth icon
             if(furi_hal_rtc_is_flag_set(FuriHalRtcFlagStealthMode)) {
                 view_port_enabled_set(
                     desktop->stealth_mode_icon_viewport, desktop->settings.stealth_icon);
+                view_port_enabled_set(desktop->stealth_mode_icon_slim_viewport, false);
             }
+            //sdcard icon
+            view_port_enabled_set(desktop->sdcard_icon_viewport, desktop->settings.sdcard);
+            view_port_enabled_set(desktop->sdcard_icon_slim_viewport, false);
+            //bt icon
+            view_port_enabled_set(desktop->bt_icon_viewport, desktop->settings.bt_icon);
+            view_port_enabled_set(desktop->bt_icon_slim_viewport, false);
             break;
         }
 

--- a/applications/services/power/power_service/power.c
+++ b/applications/services/power/power_service/power.c
@@ -501,6 +501,54 @@ static void power_check_low_battery(Power* power) {
     }
 }
 
+void power_update_viewport(Power* power) {
+    DesktopSettings* settings = malloc(sizeof(DesktopSettings));
+    bool loaded = DESKTOP_SETTINGS_LOAD(settings);
+
+    if(!loaded) {
+        settings->displayBatteryPercentage = DISPLAY_BATTERY_BAR_PERCENT;
+        settings->icon_style = ICON_STYLE_SLIM;
+    }
+
+    if(power->displayBatteryPercentage == DISPLAY_BATTERY_NONE) {
+        if(settings->displayBatteryPercentage != DISPLAY_BATTERY_NONE) {
+            power->displayBatteryPercentage = settings->displayBatteryPercentage;
+            switch(settings->icon_style) {
+            case ICON_STYLE_SLIM:
+                view_port_enabled_set(power->battery_slim_view_port, true);
+                view_port_enabled_set(power->battery_view_port, false);
+                view_port_update(power->battery_slim_view_port);
+                break;
+            case ICON_STYLE_STOCK:
+                view_port_enabled_set(power->battery_slim_view_port, false);
+                view_port_enabled_set(power->battery_view_port, true);
+                view_port_update(power->battery_view_port);
+                break;
+            }
+        }
+    } else {
+        if(settings->displayBatteryPercentage == DISPLAY_BATTERY_NONE) {
+            power->displayBatteryPercentage = settings->displayBatteryPercentage;
+            view_port_enabled_set(power->battery_slim_view_port, false);
+            view_port_enabled_set(power->battery_view_port, false);
+        } else {
+            power->displayBatteryPercentage = settings->displayBatteryPercentage;
+            switch(settings->icon_style) {
+            case ICON_STYLE_SLIM:
+                view_port_enabled_set(power->battery_slim_view_port, true);
+                view_port_enabled_set(power->battery_view_port, false);
+                view_port_update(power->battery_slim_view_port);
+                break;
+            case ICON_STYLE_STOCK:
+                view_port_enabled_set(power->battery_slim_view_port, false);
+                view_port_enabled_set(power->battery_view_port, true);
+                view_port_update(power->battery_view_port);
+                break;
+            }
+        }
+    }
+}
+
 static void power_check_battery_level_change(Power* power) {
     if(power->battery_level != power->info.charge) {
         power->battery_level = power->info.charge;
@@ -541,16 +589,18 @@ int32_t power_srv(void* p) {
         case ICON_STYLE_SLIM:
             view_port_enabled_set(power->battery_slim_view_port, true);
             view_port_enabled_set(power->battery_view_port, false);
+            view_port_update(power->battery_slim_view_port);
             break;
         case ICON_STYLE_STOCK:
             view_port_enabled_set(power->battery_slim_view_port, false);
             view_port_enabled_set(power->battery_view_port, true);
+            view_port_update(power->battery_view_port);
             break;
         }
     } else {
         power->displayBatteryPercentage = settings->displayBatteryPercentage;
-        view_port_enabled_set(power->battery_view_port, false);
         view_port_enabled_set(power->battery_slim_view_port, false);
+        view_port_enabled_set(power->battery_view_port, false);
     }
 
     free(settings);
@@ -588,8 +638,8 @@ int32_t power_srv(void* p) {
                         view_port_update(power->battery_slim_view_port);
                         break;
                     case ICON_STYLE_STOCK:
-                        view_port_enabled_set(power->battery_view_port, true);
                         view_port_enabled_set(power->battery_slim_view_port, false);
+                        view_port_enabled_set(power->battery_view_port, true);
                         view_port_update(power->battery_view_port);
                         break;
                     }
@@ -597,15 +647,19 @@ int32_t power_srv(void* p) {
             } else {
                 if(settings->displayBatteryPercentage == DISPLAY_BATTERY_NONE) {
                     power->displayBatteryPercentage = settings->displayBatteryPercentage;
-                    view_port_enabled_set(power->battery_view_port, false);
                     view_port_enabled_set(power->battery_slim_view_port, false);
+                    view_port_enabled_set(power->battery_view_port, false);
                 } else {
                     power->displayBatteryPercentage = settings->displayBatteryPercentage;
                     switch(settings->icon_style) {
                     case ICON_STYLE_SLIM:
+                        view_port_enabled_set(power->battery_slim_view_port, true);
+                        view_port_enabled_set(power->battery_view_port, false);
                         view_port_update(power->battery_slim_view_port);
                         break;
                     case ICON_STYLE_STOCK:
+                        view_port_enabled_set(power->battery_slim_view_port, false);
+                        view_port_enabled_set(power->battery_view_port, true);
                         view_port_update(power->battery_view_port);
                         break;
                     }

--- a/applications/services/power/power_service/power.h
+++ b/applications/services/power/power_service/power.h
@@ -102,6 +102,12 @@ bool power_is_battery_healthy(Power* power);
  */
 void power_enable_low_battery_level_notification(Power* power, bool enable);
 
+/** Update battery viewport
+ *
+ * @param power     Power instance
+ */
+void power_update_viewport(Power* power);
+
 #ifdef __cplusplus
 }
 #endif

--- a/applications/services/rpc/rpc_gui.c
+++ b/applications/services/rpc/rpc_gui.c
@@ -395,6 +395,7 @@ void* rpc_system_gui_alloc(RpcSession* session) {
             case ICON_STYLE_SLIM:
                 view_port_enabled_set(
                     rpc_gui->rpc_session_active_viewport_slim, rpc_gui->settings.rpc_icon);
+                view_port_enabled_set(rpc_gui->rpc_session_active_viewport, false);
                 view_port_update(rpc_gui->rpc_session_active_viewport_slim);
                 gui_add_view_port(
                     rpc_gui->gui,
@@ -402,6 +403,7 @@ void* rpc_system_gui_alloc(RpcSession* session) {
                     GuiLayerStatusBarLeftSlim);
                 break;
             case ICON_STYLE_STOCK:
+                view_port_enabled_set(rpc_gui->rpc_session_active_viewport_slim, false);
                 view_port_enabled_set(
                     rpc_gui->rpc_session_active_viewport, rpc_gui->settings.rpc_icon);
                 view_port_update(rpc_gui->rpc_session_active_viewport);
@@ -410,35 +412,15 @@ void* rpc_system_gui_alloc(RpcSession* session) {
                 break;
             }
         } else {
-            view_port_enabled_set(rpc_gui->rpc_session_active_viewport, true);
-            view_port_update(rpc_gui->rpc_session_active_viewport);
-            gui_add_view_port(
-                rpc_gui->gui, rpc_gui->rpc_session_active_viewport, GuiLayerStatusBarLeft);
-        }
-    } else {
-        if(loaded) {
-            switch(rpc_gui->settings.icon_style) {
-            case ICON_STYLE_SLIM:
-                view_port_enabled_set(rpc_gui->rpc_session_active_viewport_slim, false);
-                view_port_update(rpc_gui->rpc_session_active_viewport_slim);
-                gui_add_view_port(
-                    rpc_gui->gui,
-                    rpc_gui->rpc_session_active_viewport_slim,
-                    GuiLayerStatusBarLeftSlim);
-                break;
-            case ICON_STYLE_STOCK:
-                view_port_enabled_set(rpc_gui->rpc_session_active_viewport, false);
-                view_port_update(rpc_gui->rpc_session_active_viewport);
-                gui_add_view_port(
-                    rpc_gui->gui, rpc_gui->rpc_session_active_viewport, GuiLayerStatusBarLeft);
-                break;
-            }
-        } else {
+            view_port_enabled_set(rpc_gui->rpc_session_active_viewport_slim, true);
             view_port_enabled_set(rpc_gui->rpc_session_active_viewport, false);
             view_port_update(rpc_gui->rpc_session_active_viewport);
             gui_add_view_port(
-                rpc_gui->gui, rpc_gui->rpc_session_active_viewport, GuiLayerStatusBarLeft);
+                rpc_gui->gui, rpc_gui->rpc_session_active_viewport, GuiLayerStatusBarLeftSlim);
         }
+    } else {
+        view_port_enabled_set(rpc_gui->rpc_session_active_viewport_slim, false);
+        view_port_enabled_set(rpc_gui->rpc_session_active_viewport, false);
     }
 
     /*

--- a/applications/settings/desktop_settings/scenes/desktop_settings_scene_start.c
+++ b/applications/settings/desktop_settings/scenes/desktop_settings_scene_start.c
@@ -3,6 +3,7 @@
 
 #include "../desktop_settings_app.h"
 #include "desktop_settings_scene.h"
+#include <power/power_service/power.h>
 
 #define SCENE_EVENT_SELECT_FAVORITE_PRIMARY 0
 #define SCENE_EVENT_SELECT_FAVORITE_SECONDARY 1
@@ -68,27 +69,27 @@ const char* const desktop_on_off_text[DESKTOP_ON_OFF_COUNT] = {
 };
 
 const uint32_t lockicon_value[DESKTOP_ON_OFF_COUNT] = {false, true};
-uint8_t origLockIcon_value = true;
+//uint8_t origLockIcon_value = true;
 
 const uint32_t bticon_value[DESKTOP_ON_OFF_COUNT] = {false, true};
-uint8_t origBTIcon_value = true;
+//uint8_t origBTIcon_value = true;
 
 const uint32_t rpc_value[DESKTOP_ON_OFF_COUNT] = {false, true};
-uint8_t origRPC_value = true;
+//uint8_t origRPC_value = true;
 
 const uint32_t sdcard_value[DESKTOP_ON_OFF_COUNT] = {false, true};
-uint8_t origSDCard_value = true;
+//uint8_t origSDCard_value = true;
 
 const uint32_t stealth_value[DESKTOP_ON_OFF_COUNT] = {false, true};
-uint8_t origStealth_value = true;
+//uint8_t origStealth_value = true;
 
 const uint32_t topbar_value[DESKTOP_ON_OFF_COUNT] = {false, true};
-uint8_t origTopBar_value = true;
+//uint8_t origTopBar_value = true;
 
 const uint32_t dumbmode_value[DESKTOP_ON_OFF_COUNT] = {false, true};
 
 const uint32_t dumbmode_icon_value[DESKTOP_ON_OFF_COUNT] = {false, true};
-uint8_t origDumbIcon_value = true;
+//uint8_t origDumbIcon_value = true;
 
 static void desktop_settings_scene_start_var_list_enter_callback(void* context, uint32_t index) {
     DesktopSettingsApp* app = context;
@@ -196,6 +197,7 @@ void desktop_settings_scene_start_on_enter(void* context) {
     VariableItemList* variable_item_list = app->variable_item_list;
     origIconStyle_value = app->settings.icon_style;
     origBattDisp_value = app->settings.displayBatteryPercentage;
+    /*
     origLockIcon_value = app->settings.lock_icon;
     origBTIcon_value = app->settings.bt_icon;
     origRPC_value = app->settings.rpc_icon;
@@ -203,6 +205,7 @@ void desktop_settings_scene_start_on_enter(void* context) {
     origStealth_value = app->settings.stealth_icon;
     origTopBar_value = app->settings.top_bar;
     origDumbIcon_value = app->settings.dumbmode_icon;
+	*/
 
     VariableItem* item;
     uint8_t value_index;
@@ -438,6 +441,13 @@ void desktop_settings_scene_start_on_exit(void* context) {
     DESKTOP_SETTINGS_SAVE(&app->settings);
 
     if((app->settings.icon_style != origIconStyle_value) ||
+       (app->settings.displayBatteryPercentage != origBattDisp_value)) {
+        Power* power = furi_record_open(RECORD_POWER);
+        power_update_viewport(power);
+        furi_record_close(RECORD_POWER);
+    }
+    /*
+    if((app->settings.icon_style != origIconStyle_value) ||
        (app->settings.displayBatteryPercentage != origBattDisp_value) ||
        (app->settings.lock_icon != origLockIcon_value) ||
        (app->settings.bt_icon != origBTIcon_value) || (app->settings.rpc_icon != origRPC_value) ||
@@ -447,4 +457,5 @@ void desktop_settings_scene_start_on_exit(void* context) {
        (app->settings.dumbmode_icon != origDumbIcon_value)) {
         furi_hal_power_reset();
     }
+	*/
 }

--- a/firmware/targets/f7/api_symbols.csv
+++ b/firmware/targets/f7/api_symbols.csv
@@ -1,5 +1,5 @@
 entry,status,name,type,params
-Version,+,23.0,,
+Version,+,23.1,,
 Header,+,applications/services/bt/bt_service/bt.h,,
 Header,+,applications/services/cli/cli.h,,
 Header,+,applications/services/cli/cli_vcp.h,,
@@ -2243,6 +2243,7 @@ Function,+,power_get_settings_events_pubsub,FuriPubSub*,Power*
 Function,+,power_is_battery_healthy,_Bool,Power*
 Function,+,power_off,void,Power*
 Function,+,power_reboot,void,PowerBootMode
+Function,+,power_update_viewport,void,Power*
 Function,+,powf,float,"float, float"
 Function,-,powl,long double,"long double, long double"
 Function,+,pretty_format_bytes_hex_canonical,void,"FuriString*, size_t, const char*, const uint8_t*, size_t"


### PR DESCRIPTION
- Desktop Settings Update - No more reboot needed
- Cleaned up some viewport code in Power/RPC/Desktop Services

Small bug with RPC icon setting. When settings are changed and RPC is in use, icon won't update until RPC disconnects and reconnects. Usually this is just a simple matter of disconnecting/reconnecting USB to refresh the icon. Not going to fix (for now)