### PR TITLE
Fix small issue with Passport App

### DIFF
--- a/applications/settings/passport_app/passport.h
+++ b/applications/settings/passport_app/passport.h
@@ -19,9 +19,9 @@
 #define MOODS_TOTAL 1
 #define BUTTHURT_MAX 14
 
-typedef enum { AniRedVirus, AniYelVirus, AniBluVirus, AniRabbit, AniSlime, AniSonic } Animations;
+typedef enum { AniRedVirus, AniYelVirus, AniBluVirus, AniRabbit, AniSlime, AniSonic, AniMaxNum } Animations;
 
-static IconAnimation* animations[5];
+static IconAnimation* animations[AniMaxNum];
 
 typedef enum { EventGameTick, EventKeyPress } EventType;
 


### PR DESCRIPTION
Adding an animation resulted in an small sizing error due to array size of `Animations`. I added a variable within the `Animations` array to act as the max number of array items for the `IconAnimation* animations` variable size.