### PR TITLE
expose external gpio pins for infrared application without needing debug enabled

### DIFF
--- a/applications/main/infrared/scenes/infrared_scene_start.c
+++ b/applications/main/infrared/scenes/infrared_scene_start.c
@@ -51,13 +51,14 @@ void infrared_scene_start_on_enter(void* context) {
             SubmenuIndexDebug,
             infrared_scene_start_submenu_callback,
             infrared);
-        submenu_add_item(
-            submenu,
-            "Debug Settings",
-            SubmenuIndexDebugSettings,
-            infrared_scene_start_submenu_callback,
-            infrared);
-    }
+        }
+
+    submenu_add_item(
+        submenu,
+        "PIN Settings",
+        SubmenuIndexDebugSettings,
+        infrared_scene_start_submenu_callback,
+        infrared);
 
     const uint32_t submenu_index =
         scene_manager_get_scene_state(scene_manager, InfraredSceneStart);


### PR DESCRIPTION
# What's new

-  Due to debug not allowing deep sleep, I exposed pin settings so that people can use external IR modules without the need of debug enabled. This will allow people to use external modules without a battery life sacrifice.

# Verification 

- Open the Infrared application with & without debug enabled and check for 'Pin Settings'

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
