### PR TITLE
Fix Music Player crash - Removed folder migration

### DIFF
--- a/applications/external/music_beeper/music_beeper.c
+++ b/applications/external/music_beeper/music_beeper.c
@@ -313,6 +313,7 @@ int32_t music_beeper_app(void* p) {
             dialog_file_browser_set_basic_options(
                 &browser_options, MUSIC_BEEPER_APP_EXTENSION, &I_music_10px);
             browser_options.hide_ext = false;
+            browser_options.base_path = MUSIC_BEEPER_APP_PATH_FOLDER;
 
             DialogsApp* dialogs = furi_record_open(RECORD_DIALOGS);
             bool res = dialog_file_browser_show(dialogs, file_path, file_path, &browser_options);

--- a/applications/external/music_player/music_player.c
+++ b/applications/external/music_player/music_player.c
@@ -313,6 +313,7 @@ int32_t music_player_app(void* p) {
             dialog_file_browser_set_basic_options(
                 &browser_options, MUSIC_PLAYER_APP_EXTENSION, &I_music_10px);
             browser_options.hide_ext = false;
+            browser_options.base_path = MUSIC_PLAYER_APP_PATH_FOLDER;
 
             DialogsApp* dialogs = furi_record_open(RECORD_DIALOGS);
             bool res = dialog_file_browser_show(dialogs, file_path, file_path, &browser_options);

--- a/applications/external/music_player/music_player.c
+++ b/applications/external/music_player/music_player.c
@@ -10,6 +10,7 @@
 
 #define TAG "MusicPlayer"
 
+#define MUSIC_PLAYER_APP_PATH_FOLDER ANY_PATH("apps_data/music_player")
 #define MUSIC_PLAYER_APP_EXTENSION "*"
 
 #define MUSIC_PLAYER_SEMITONE_HISTORY_SIZE 4
@@ -306,24 +307,17 @@ int32_t music_player_app(void* p) {
         if(p && strlen(p)) {
             furi_string_set(file_path, (const char*)p);
         } else {
-            Storage* storage = furi_record_open(RECORD_STORAGE);
-            storage_common_migrate(
-                storage, EXT_PATH("music_player"), STORAGE_APP_DATA_PATH_PREFIX);
-            furi_record_close(RECORD_STORAGE);
-
-            furi_string_set(file_path, STORAGE_APP_DATA_PATH_PREFIX);
+            furi_string_set(file_path, MUSIC_PLAYER_APP_PATH_FOLDER);
 
             DialogsFileBrowserOptions browser_options;
             dialog_file_browser_set_basic_options(
                 &browser_options, MUSIC_PLAYER_APP_EXTENSION, &I_music_10px);
             browser_options.hide_ext = false;
-            browser_options.base_path = STORAGE_APP_DATA_PATH_PREFIX;
 
             DialogsApp* dialogs = furi_record_open(RECORD_DIALOGS);
             bool res = dialog_file_browser_show(dialogs, file_path, file_path, &browser_options);
 
             furi_record_close(RECORD_DIALOGS);
-
             if(!res) {
                 FURI_LOG_E(TAG, "No file selected");
                 break;


### PR DESCRIPTION
Folder migration was causing a hang. Removed, and moved folder to apps_data\music_player like Music Beeper app.

Also added back the browser_options.base_path to lock application within the `apps_data\music_player` folder. Added this to Music Beeper too