### PR TITLE
Small Fixes for application order in Main Menu & safer application launch from Desktop

### DIFF
--- a/applications/services/desktop/scenes/desktop_scene_main.c
+++ b/applications/services/desktop/scenes/desktop_scene_main.c
@@ -81,7 +81,10 @@ static void desktop_scene_main_open_app_or_profile(Desktop* desktop, const char*
 
 static void desktop_scene_main_start_favorite(Desktop* desktop, FavoriteApp* application) {
     if(application->name_or_path) {
-        loader_start(desktop->loader, application->name_or_path, NULL, NULL);
+        if(loader_start_with_gui_error(desktop->loader, application->name_or_path, NULL) !=
+           LoaderStatusOk) {
+            loader_start(desktop->loader, LOADER_APPLICATIONS_NAME, NULL, NULL);
+        }
     } else {
         loader_start(desktop->loader, LOADER_APPLICATIONS_NAME, NULL, NULL);
     }

--- a/applications/services/gui/modules/menu.c
+++ b/applications/services/gui/modules/menu.c
@@ -249,7 +249,7 @@ static void menu_exit(void* context) {
     furi_timer_stop(menu->scroll_timer);
 }
 
-Menu* menu_pos_alloc(size_t pos) {
+Menu* menu_alloc() {
     Menu* menu = malloc(sizeof(Menu));
     menu->view = view_alloc(menu->view);
     view_set_context(menu->view, menu);
@@ -266,7 +266,7 @@ Menu* menu_pos_alloc(size_t pos) {
         MenuModel * model,
         {
             MenuItemArray_init(model->items);
-            model->position = pos;
+            model->position = 0;
         },
         true);
 

--- a/applications/services/gui/modules/menu.h
+++ b/applications/services/gui/modules/menu.h
@@ -17,12 +17,11 @@ typedef struct Menu Menu;
 /** Menu Item Callback */
 typedef void (*MenuItemCallback)(void* context, uint32_t index);
 
-/** Menu allocation and initialization with positioning
+/** Menu allocation and initialization
  *
  * @return     Menu instance
- * @param      pos  size_t position
  */
-Menu* menu_pos_alloc(size_t pos);
+Menu* menu_alloc();
 
 /** Free menu
  *

--- a/applications/services/loader/loader_menu.c
+++ b/applications/services/loader/loader_menu.c
@@ -52,7 +52,7 @@ static void loader_menu_start(const char* name) {
     furi_record_close(RECORD_LOADER);
 }
 
-static bool loader_menu_check_appid(size_t index, bool settings) {
+static bool loader_menu_check_appid(uint32_t index, bool settings) {
     if(settings) {
         if(strstr(FLIPPER_SETTINGS_APPS[index].appid, ".fap")) {
             return true;

--- a/applications/services/loader/loader_menu.h
+++ b/applications/services/loader/loader_menu.h
@@ -2,6 +2,8 @@
 #include <furi.h>
 #include "loader_extapps.h"
 
+#define MANUALLY_ADDED_ITEMS_COUNT 2
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/firmware/targets/f7/api_symbols.csv
+++ b/firmware/targets/f7/api_symbols.csv
@@ -1,5 +1,5 @@
 entry,status,name,type,params
-Version,+,31.3,,
+Version,+,31.2,,
 Header,+,applications/main/subghz/helpers/subghz_txrx.h,,
 Header,+,applications/services/bt/bt_service/bt.h,,
 Header,+,applications/services/cli/cli.h,,
@@ -2059,9 +2059,9 @@ Function,-,mempcpy,void*,"void*, const void*, size_t"
 Function,-,memrchr,void*,"const void*, int, size_t"
 Function,+,memset,void*,"void*, int, size_t"
 Function,+,menu_add_item,void,"Menu*, const char*, const Icon*, uint32_t, MenuItemCallback, void*"
+Function,+,menu_alloc,Menu*,
 Function,+,menu_free,void,Menu*
 Function,+,menu_get_view,View*,Menu*
-Function,+,menu_pos_alloc,Menu*,size_t
 Function,+,menu_reset,void,Menu*
 Function,+,menu_set_selected_item,void,"Menu*, uint32_t"
 Function,-,mf_classic_auth_attempt,_Bool,"FuriHalNfcTxRxContext*, Crypto1*, MfClassicAuthContext*, uint64_t"


### PR DESCRIPTION
- Fixed `Main Menu` order rearrangement causing loading of offset menu items
  - Reverted menu changes from previous commit (https://github.com/RogueMaster/flipperzero-firmware-wPlugins/commit/f69a8750c025cf690dd062a62bc6fe06ed40b339)
- Added small function change in `Desktop` for safer loading of apps