### PR TITLE
Loader Menu changes -- again.

### DIFF
--- a/applications/services/gui/modules/menu.c
+++ b/applications/services/gui/modules/menu.c
@@ -273,6 +273,28 @@ Menu* menu_alloc() {
     return menu;
 }
 
+Menu* menu_pos_alloc(size_t pos) {
+    Menu* menu = malloc(sizeof(Menu));
+    menu->view = view_alloc(menu->view);
+    view_set_context(menu->view, menu);
+    view_allocate_model(menu->view, ViewModelTypeLocking, sizeof(MenuModel));
+    view_set_draw_callback(menu->view, menu_draw_callback);
+    view_set_input_callback(menu->view, menu_input_callback);
+    view_set_enter_callback(menu->view, menu_enter);
+    view_set_exit_callback(menu->view, menu_exit);
+    menu->scroll_timer = furi_timer_alloc(menu_scroll_timer_callback, FuriTimerTypePeriodic, menu);
+    with_view_model(
+        menu->view,
+        MenuModel * model,
+        {
+            MenuItemArray_init(model->items);
+            model->position = pos;
+        },
+        true);
+
+    return menu;
+}
+
 void menu_free(Menu* menu) {
     furi_assert(menu);
     menu_reset(menu);

--- a/applications/services/gui/modules/menu.h
+++ b/applications/services/gui/modules/menu.h
@@ -23,6 +23,13 @@ typedef void (*MenuItemCallback)(void* context, uint32_t index);
  */
 Menu* menu_alloc();
 
+/** Menu allocation and initialization with positioning
+ *
+ * @return     Menu instance
+ * @param      pos  size_t position
+ */
+Menu* menu_pos_alloc(size_t pos);
+
 /** Free menu
  *
  * @param      menu  Menu instance

--- a/applications/services/loader/loader_cli.c
+++ b/applications/services/loader/loader_cli.c
@@ -16,13 +16,21 @@ static void loader_cli_print_usage() {
 static void loader_cli_list() {
     printf("Applications:\r\n");
     for(size_t i = 0; i < FLIPPER_APPS_COUNT; i++) {
-        printf("\t%s\r\n", FLIPPER_APPS[i].name);
+        if(strstr(FLIPPER_APPS[i].name, " ")) {
+            printf("\t\"%s\"\r\n", FLIPPER_APPS[i].name);
+        } else {
+            printf("\t%s\r\n", FLIPPER_APPS[i].name);
+        }
     }
     printf("Settings:\r\n");
     for(size_t i = 0; i < FLIPPER_SETTINGS_APPS_COUNT; i++) {
-        printf("\t%s\r\n", FLIPPER_SETTINGS_APPS[i].name);
+        if(strstr(FLIPPER_SETTINGS_APPS[i].name, " ")) {
+            printf("\t\"%s\"\r\n", FLIPPER_SETTINGS_APPS[i].name);
+        } else {
+            printf("\t%s\r\n", FLIPPER_SETTINGS_APPS[i].name);
+        }
     }
-    printf("For External Apps, specify full path to .fap file");
+    printf("For External Apps, specify full path to .fap file.");
 }
 
 static void loader_cli_info(Loader* loader) {

--- a/applications/services/loader/loader_menu.c
+++ b/applications/services/loader/loader_menu.c
@@ -69,11 +69,11 @@ static bool loader_menu_check_appid(uint32_t index, bool settings) {
 static void loader_menu_callback(void* context, uint32_t index) {
     UNUSED(context);
 
-    if(loader_menu_check_appid(index - 1, false)) {
-        const char* name = FLIPPER_APPS[index - 1].appid;
+    if(loader_menu_check_appid(index, false)) {
+        const char* name = FLIPPER_APPS[index].appid;
         loader_menu_start(name);
     } else {
-        const char* name = FLIPPER_APPS[index - 1].name;
+        const char* name = FLIPPER_APPS[index].name;
         loader_menu_start(name);
     }
 }
@@ -124,26 +124,19 @@ static void loader_menu_build_menu(LoaderMenuApp* app, LoaderMenu* menu) {
     size_t i;
     size_t x = 0;
     size_t ext_apps_size = loader_get_ext_main_app_list_size(loader);
+    size_t total_items = FLIPPER_APPS_COUNT + ext_apps_size + MANUALLY_ADDED_ITEMS_COUNT;
 
-    for(i = 0; i < (FLIPPER_APPS_COUNT + ext_apps_size + MANUALLY_ADDED_ITEMS_COUNT); i++) {
-        if(i == 0) {
+    for(i = 0; i < total_items; i++) {
+        if(i < FLIPPER_APPS_COUNT) {
             menu_add_item(
                 app->primary_menu,
-                LOADER_APPLICATIONS_NAME,
-                &A_Plugins_14,
-                i,
-                loader_menu_applications_callback,
-                (void*)menu);
-        } else if(i <= FLIPPER_APPS_COUNT) {
-            menu_add_item(
-                app->primary_menu,
-                FLIPPER_APPS[i - 1].name,
-                FLIPPER_APPS[i - 1].icon,
+                FLIPPER_APPS[i].name,
+                FLIPPER_APPS[i].icon,
                 i,
                 loader_menu_callback,
                 (void*)menu);
         } else if(i > FLIPPER_APPS_COUNT) {
-            if(i == (FLIPPER_APPS_COUNT + 1)) {
+            if(i == FLIPPER_APPS_COUNT) {
                 menu_add_item(
                     app->primary_menu,
                     "Settings",
@@ -151,7 +144,7 @@ static void loader_menu_build_menu(LoaderMenuApp* app, LoaderMenu* menu) {
                     i,
                     loader_menu_switch_to_settings,
                     app);
-            } else {
+            } else if(i <= (FLIPPER_APPS_COUNT + ext_apps_size)) {
                 const ExtMainApp* ext_app = loader_get_ext_main_app_item(loader, x);
 
                 menu_add_item(
@@ -163,6 +156,14 @@ static void loader_menu_build_menu(LoaderMenuApp* app, LoaderMenu* menu) {
                     (void*)menu);
 
                 x++;
+            } else {
+                menu_add_item(
+                    app->primary_menu,
+                    LOADER_APPLICATIONS_NAME,
+                    &A_Plugins_14,
+                    i,
+                    loader_menu_applications_callback,
+                    (void*)menu);
             }
         }
     }
@@ -185,7 +186,7 @@ static LoaderMenuApp* loader_menu_app_alloc(LoaderMenu* loader_menu) {
     LoaderMenuApp* app = malloc(sizeof(LoaderMenuApp));
     app->gui = furi_record_open(RECORD_GUI);
     app->view_dispatcher = view_dispatcher_alloc();
-    app->primary_menu = menu_alloc();
+    app->primary_menu = menu_pos_alloc(0);
     app->settings_menu = submenu_alloc();
 
     loader_menu_build_menu(app, loader_menu);

--- a/firmware/targets/f7/api_symbols.csv
+++ b/firmware/targets/f7/api_symbols.csv
@@ -1,5 +1,5 @@
 entry,status,name,type,params
-Version,+,31.2,,
+Version,+,31.3,,
 Header,+,applications/main/subghz/helpers/subghz_txrx.h,,
 Header,+,applications/services/bt/bt_service/bt.h,,
 Header,+,applications/services/cli/cli.h,,
@@ -2062,6 +2062,7 @@ Function,+,menu_add_item,void,"Menu*, const char*, const Icon*, uint32_t, MenuIt
 Function,+,menu_alloc,Menu*,
 Function,+,menu_free,void,Menu*
 Function,+,menu_get_view,View*,Menu*
+Function,+,menu_pos_alloc,Menu*,size_t
 Function,+,menu_reset,void,Menu*
 Function,+,menu_set_selected_item,void,"Menu*, uint32_t"
 Function,-,mf_classic_auth_attempt,_Bool,"FuriHalNfcTxRxContext*, Crypto1*, MfClassicAuthContext*, uint64_t"


### PR DESCRIPTION
- Rearranged the menu order to eliminate modifying the index.
  - `FLIPPER_APPS` gets added to menu normally
  - `Applications` gets added to menu last
- Added back in `menu_pos_alloc` as it can be useful later.
- Small update to `loader_cli`
  - Added quotations for apps with spaces in the name as `Loader` would otherwise think an argument was specified after the first space in the application name