### PR TITLE
Small fixes

### DIFF
--- a/applications/services/desktop/scenes/desktop_scene_main.c
+++ b/applications/services/desktop/scenes/desktop_scene_main.c
@@ -84,9 +84,9 @@ static void desktop_scene_main_start_favorite(Desktop* desktop, FavoriteApp* app
         if(loader_start_with_gui_error(desktop->loader, application->name_or_path, NULL) !=
            LoaderStatusOk) {
             loader_start(desktop->loader, LOADER_APPLICATIONS_NAME, NULL, NULL);
-        } else {
-            loader_start(desktop->loader, LOADER_APPLICATIONS_NAME, NULL, NULL);
         }
+    } else if(strcmp(application->name_or_path, "d") != 0) {
+        loader_start(desktop->loader, LOADER_APPLICATIONS_NAME, NULL, NULL);
     }
 }
 

--- a/applications/services/loader/loader_cli.c
+++ b/applications/services/loader/loader_cli.c
@@ -9,12 +9,16 @@ static void loader_cli_print_usage() {
     printf("loader <cmd> <args>\r\n");
     printf("Cmd list:\r\n");
     printf("\tlist\t - List available applications\r\n");
-    printf("\topen <Application Name:string>\t - Open application by name\r\n");
+    printf(
+        "\topen \"<Application Name:string>\" \"<parameter:string>\"\t - Open application by name with (optional) parameter\r\n");
     printf("\tinfo\t - Show loader state\r\n");
 }
 
 static void loader_cli_list() {
     printf("Applications:\r\n");
+    for(size_t i = 0; i < FLIPPER_EXTERNAL_APPS_COUNT; i++) {
+        printf("\t%s\r\n", FLIPPER_EXTERNAL_APPS[i].name);
+    }
     for(size_t i = 0; i < FLIPPER_APPS_COUNT; i++) {
         printf("\t%s\r\n", FLIPPER_APPS[i].name);
     }
@@ -22,6 +26,8 @@ static void loader_cli_list() {
     for(size_t i = 0; i < FLIPPER_SETTINGS_APPS_COUNT; i++) {
         printf("\t%s\r\n", FLIPPER_SETTINGS_APPS[i].name);
     }
+    printf(
+        "For external applications, specify full path to '.fap' file.\r\nExample: \"/ext/apps/Main/clock.fap\"");
 }
 
 static void loader_cli_info(Loader* loader) {
@@ -33,28 +39,52 @@ static void loader_cli_info(Loader* loader) {
     }
 }
 
+static const char* loader_cli_check_external_app_by_name(const char* app_name) {
+    for(size_t i = 0; i < FLIPPER_EXTERNAL_APPS_COUNT; i++) {
+        if(strcmp(FLIPPER_EXTERNAL_APPS[i].name, app_name) == 0) {
+            return FLIPPER_EXTERNAL_APPS[i].path;
+        }
+    }
+
+    return NULL;
+}
+
 static void loader_cli_open(FuriString* args, Loader* loader) {
     FuriString* app_name = furi_string_alloc();
+    FuriString* param = furi_string_alloc();
 
     do {
         if(!args_read_probably_quoted_string_and_trim(args, app_name)) {
             printf("No application provided\r\n");
             break;
         }
-        furi_string_trim(args);
+        args_read_probably_quoted_string_and_trim(args, param);
 
-        const char* args_str = furi_string_get_cstr(args);
+        furi_string_trim(param);
+
+        const char* args_str = furi_string_get_cstr(param);
         if(strlen(args_str) == 0) {
             args_str = NULL;
         }
 
-        const char* app_name_str = furi_string_get_cstr(app_name);
+        const char* app_name_ext =
+            loader_cli_check_external_app_by_name(furi_string_get_cstr(app_name));
 
-        FuriString* error_message = furi_string_alloc();
-        if(loader_start(loader, app_name_str, args_str, error_message) != LoaderStatusOk) {
-            printf("%s\r\n", furi_string_get_cstr(error_message));
+        if(app_name_ext) {
+            FuriString* error_message = furi_string_alloc();
+            if(loader_start(loader, app_name_ext, args_str, error_message) != LoaderStatusOk) {
+                printf("%s\r\n", furi_string_get_cstr(error_message));
+            }
+            furi_string_free(error_message);
+        } else {
+            const char* app_name_str = furi_string_get_cstr(app_name);
+
+            FuriString* error_message = furi_string_alloc();
+            if(loader_start(loader, app_name_str, args_str, error_message) != LoaderStatusOk) {
+                printf("%s\r\n", furi_string_get_cstr(error_message));
+            }
+            furi_string_free(error_message);
         }
-        furi_string_free(error_message);
     } while(false);
 
     furi_string_free(app_name);

--- a/applications/services/loader/loader_menu.c
+++ b/applications/services/loader/loader_menu.c
@@ -53,16 +53,10 @@ static void loader_menu_start(const char* name) {
     furi_record_close(RECORD_LOADER);
 }
 
-static void loader_menu_apps_callback(void* context, uint32_t index) {
+static void loader_menu_callback(void* context, uint32_t index) {
     UNUSED(context);
-    const char* name = FLIPPER_APPS[index].name;
+    const char* name = (const char*)index;
     loader_menu_start(name);
-}
-
-static void loader_menu_external_apps_callback(void* context, uint32_t index) {
-    UNUSED(context);
-    const char* path = FLIPPER_EXTERNAL_APPS[index].name;
-    loader_menu_start(path);
 }
 
 static void loader_menu_applications_callback(void* context, uint32_t index) {
@@ -97,28 +91,43 @@ static uint32_t loader_menu_exit(void* context) {
 static void loader_menu_build_menu(LoaderMenuApp* app, LoaderMenu* menu) {
     Loader* loader = furi_record_open(RECORD_LOADER);
     size_t i;
+    size_t count = 0;
     size_t ext_apps_size = loader_get_ext_main_app_list_size(loader);
 
+    //Applications item
+    menu_add_item(
+        app->primary_menu,
+        LOADER_APPLICATIONS_NAME,
+        &A_Plugins_14,
+        count,
+        loader_menu_applications_callback,
+        (void*)menu);
+
+    //External Apps
     for(i = 0; i < FLIPPER_EXTERNAL_APPS_COUNT; i++) {
         menu_add_item(
             app->primary_menu,
             FLIPPER_EXTERNAL_APPS[i].name,
             FLIPPER_EXTERNAL_APPS[i].icon,
-            i,
-            loader_menu_external_apps_callback,
+            (uint32_t)FLIPPER_EXTERNAL_APPS[i].path,
+            loader_menu_callback,
             (void*)menu);
+        count++;
     }
 
+    //Internal Apps
     for(i = 0; i < FLIPPER_APPS_COUNT; i++) {
         menu_add_item(
             app->primary_menu,
             FLIPPER_APPS[i].name,
             FLIPPER_APPS[i].icon,
-            i,
-            loader_menu_apps_callback,
+            (uint32_t)FLIPPER_APPS[i].name,
+            loader_menu_callback,
             (void*)menu);
+        count++;
     }
 
+    //FAPs added via CFW Settings
     for(i = 0; i < ext_apps_size; i++) {
         const ExtMainApp* ext_app = loader_get_ext_main_app_item(loader, i);
         menu_add_item(
@@ -126,20 +135,16 @@ static void loader_menu_build_menu(LoaderMenuApp* app, LoaderMenu* menu) {
             ext_app->name,
             ext_app->icon,
             (uint32_t)ext_app->path,
-            loader_menu_external_apps_callback,
+            loader_menu_callback,
             (void*)menu);
+        count++;
     }
-    furi_record_close(RECORD_LOADER);
 
+    //Settings
     menu_add_item(
-        app->primary_menu, "Settings", &A_Settings_14, i++, loader_menu_switch_to_settings, app);
-    menu_add_item(
-        app->primary_menu,
-        LOADER_APPLICATIONS_NAME,
-        &A_Plugins_14,
-        i++,
-        loader_menu_applications_callback,
-        (void*)menu);
+        app->primary_menu, "Settings", &A_Settings_14, count, loader_menu_switch_to_settings, app);
+
+    furi_record_close(RECORD_LOADER);
 }
 
 static void loader_menu_build_submenu(LoaderMenuApp* app, LoaderMenu* loader_menu) {
@@ -157,8 +162,13 @@ static LoaderMenuApp* loader_menu_app_alloc(LoaderMenu* loader_menu) {
     LoaderMenuApp* app = malloc(sizeof(LoaderMenuApp));
     app->gui = furi_record_open(RECORD_GUI);
     app->view_dispatcher = view_dispatcher_alloc();
+    Loader* loader = furi_record_open(RECORD_LOADER);
+    size_t APP_COUNT =
+        (FLIPPER_APPS_COUNT + FLIPPER_EXTERNAL_APPS_COUNT +
+         (loader_get_ext_main_app_list_size(loader)) + 2);
+    furi_record_close(RECORD_LOADER);
     size_t my_start_point = (size_t)CFW_SETTINGS()->start_point;
-    if(my_start_point < 0 || my_start_point > 14) my_start_point = 0;
+    if(my_start_point < 0 || my_start_point > APP_COUNT) my_start_point = 0;
     app->primary_menu = menu_pos_alloc(my_start_point);
     app->settings_menu = submenu_alloc();
 

--- a/applications/settings/desktop_settings/scenes/desktop_settings_scene_favorite.c
+++ b/applications/settings/desktop_settings/scenes/desktop_settings_scene_favorite.c
@@ -5,7 +5,7 @@
 #include <storage/storage.h>
 #include <dialogs/dialogs.h>
 
-#define APPS_COUNT (FLIPPER_APPS_COUNT + FLIPPER_EXTERNAL_APPS_COUNT)
+#define APPS_COUNT (FLIPPER_APPS_COUNT + FLIPPER_EXTERNAL_APPS_COUNT + FLIPPER_SETTINGS_APPS_COUNT)
 
 #define EXTERNAL_BROWSER_NAME ("Applications")
 #define EXTERNAL_BROWSER_INDEX (APPS_COUNT + 1)
@@ -21,8 +21,10 @@ static const char* favorite_fap_get_app_name(size_t i) {
     const char* name;
     if(i < FLIPPER_APPS_COUNT) {
         name = FLIPPER_APPS[i].name;
-    } else {
+    } else if(i < (FLIPPER_APPS_COUNT + FLIPPER_EXTERNAL_APPS_COUNT)) {
         name = FLIPPER_EXTERNAL_APPS[i - FLIPPER_APPS_COUNT].name;
+    } else {
+        name = FLIPPER_SETTINGS_APPS[i - (FLIPPER_APPS_COUNT + FLIPPER_EXTERNAL_APPS_COUNT)].name;
     }
 
     return name;
@@ -104,20 +106,22 @@ void desktop_settings_scene_favorite_on_enter(void* context) {
         desktop_settings_scene_favorite_submenu_callback,
         app);
 
-    if(pre_select_item == PRESELECTED_SPECIAL) {
-        if(curr_favorite_app->name_or_path[0] == '\0') {
-            pre_select_item = EXTERNAL_BROWSER_INDEX;
-        } else {
-            pre_select_item = EXTERNAL_APPLICATION_INDEX;
-        }
-    }
-
     submenu_add_item(
         submenu,
         "None (disable)",
         NONE_APPLICATION_INDEX,
         desktop_settings_scene_favorite_submenu_callback,
         app);
+
+    if(pre_select_item == PRESELECTED_SPECIAL) {
+        if(curr_favorite_app->name_or_path[0] == '\0') {
+            pre_select_item = EXTERNAL_BROWSER_INDEX;
+        } else if(strcmp(curr_favorite_app->name_or_path, "d") == 0) {
+            pre_select_item = NONE_APPLICATION_INDEX;
+        } else {
+            pre_select_item = EXTERNAL_APPLICATION_INDEX;
+        }
+    }
 
     if(primary_favorite == 0) {
         submenu_set_header(submenu, "Primary favorite app:");

--- a/applications/settings/desktop_settings/scenes/desktop_settings_scene_start.c
+++ b/applications/settings/desktop_settings/scenes/desktop_settings_scene_start.c
@@ -3,7 +3,6 @@
 
 #include "../desktop_settings_app.h"
 #include "desktop_settings_scene.h"
-#include <power/power_service/power.h>
 
 #define SCENE_EVENT_SELECT_FAVORITE_PRIMARY 0
 #define SCENE_EVENT_SELECT_FAVORITE_SECONDARY 1


### PR DESCRIPTION
#### Desktop Settings
- Removed `power/power_service/power.h` reference from `Desktop Settings` Start scene as it is no longer required
- Added the ability to set `Settings` apps to `Desktop Favorites` buttons
- Fixed the way selecting `None (disabled)` and `Applications` work within `Desktop Settings` Favorites scene and `Desktop` Main scene
  - Entering `Settings` -> `Desktop` -> `Favorite` menu will return to `None (disabled)` or `Applications` if selected previously

#### Loader Menu
- Updated `CFW -> Start Point` check in `Loader Menu`
- Slightly modified how `Loader Menu` populates menu items
- Fixed issue when loading an app from the `FLIPPER_APPS` list

#### Loader CLI
- Fixed `Loader CLI` when using `loader list` command, it will populate the `Applications` list properly
- Added ability to use a parameter when using `loader open`
  - Example: `loader open "Sub-GHz" "/ext/subghz/doorbell.sub"` will load Sub-GHz app and load the `doorbell.sub` file