### PR TITLE
Changed the directory of the addresses.txt file

### DIFF
--- a/applications/external/nrf24scan/nrf24scan.c
+++ b/applications/external/nrf24scan/nrf24scan.c
@@ -18,7 +18,7 @@
 #define MAX_CHANNEL 125
 #define MAX_ADDR 6
 
-#define SCAN_APP_PATH_FOLDER "/ext/apps_data/nrf24scan"
+#define SCAN_APP_PATH_FOLDER "/ext/apps_data/nrf24sniff"
 #define SETTINGS_FILENAME "addresses.txt" // Settings file format (1 parameter per line):
 // SNIFF - if present then sniff mode
 // Rate: 0/1/2 - rate in Mbps (=0.25/1/2)


### PR DESCRIPTION
Changed the directory of the addresses.txt file to match the same used by the MouseJacker application

# What's new

The last update in the applications/external/mousejacker/mousejacker.c has changed the addresses.txt directory.
But the applications/external/nrf24scan/nrf24scan.c didn't changed the path of this directory.
So, the MouseJacker application didn't found the addresses.txt

It's my first contribution/pull request, so tell me if I make something wrong.

# Verification 

To verify, you can test if the MouseJacker application found the addresses.txt file in the "nrf24sniff" directory

# Checklist (For Reviewer)
I've not test this modification...
