### PR TITLE
Moving Internal Apps ahead of External apps for Main Menu and CFW Settings

### DIFF
--- a/applications/services/loader/loader_menu.c
+++ b/applications/services/loader/loader_menu.c
@@ -103,18 +103,6 @@ static void loader_menu_build_menu(LoaderMenuApp* app, LoaderMenu* menu) {
         loader_menu_applications_callback,
         (void*)menu);
 
-    //External Apps
-    for(i = 0; i < FLIPPER_EXTERNAL_APPS_COUNT; i++) {
-        menu_add_item(
-            app->primary_menu,
-            FLIPPER_EXTERNAL_APPS[i].name,
-            FLIPPER_EXTERNAL_APPS[i].icon,
-            (uint32_t)FLIPPER_EXTERNAL_APPS[i].path,
-            loader_menu_callback,
-            (void*)menu);
-        count++;
-    }
-
     //Internal Apps
     for(i = 0; i < FLIPPER_APPS_COUNT; i++) {
         menu_add_item(
@@ -122,6 +110,18 @@ static void loader_menu_build_menu(LoaderMenuApp* app, LoaderMenu* menu) {
             FLIPPER_APPS[i].name,
             FLIPPER_APPS[i].icon,
             (uint32_t)FLIPPER_APPS[i].name,
+            loader_menu_callback,
+            (void*)menu);
+        count++;
+    }
+
+    //External Apps
+    for(i = 0; i < FLIPPER_EXTERNAL_APPS_COUNT; i++) {
+        menu_add_item(
+            app->primary_menu,
+            FLIPPER_EXTERNAL_APPS[i].name,
+            FLIPPER_EXTERNAL_APPS[i].icon,
+            (uint32_t)FLIPPER_EXTERNAL_APPS[i].path,
             loader_menu_callback,
             (void*)menu);
         count++;

--- a/applications/settings/cfw_app/cfw_app.c
+++ b/applications/settings/cfw_app/cfw_app.c
@@ -206,12 +206,12 @@ CfwApp* cfw_app_alloc() {
 
     CharList_push_back(app->start_point_names, "Applications");
 
-    for(size_t i = 0; i < FLIPPER_EXTERNAL_APPS_COUNT; i++) {
-        CharList_push_back(app->start_point_names, strdup(FLIPPER_EXTERNAL_APPS[i].name));
-    }
-
     for(size_t i = 0; i < FLIPPER_APPS_COUNT; i++) {
         CharList_push_back(app->start_point_names, strdup(FLIPPER_APPS[i].name));
+    }
+
+    for(size_t i = 0; i < FLIPPER_EXTERNAL_APPS_COUNT; i++) {
+        CharList_push_back(app->start_point_names, strdup(FLIPPER_EXTERNAL_APPS[i].name));
     }
 
     for(size_t i = 0; i < CharList_size(app->mainmenu_app_names); i++) {


### PR DESCRIPTION
Simple flip flop on External and Internal app lists.

Done for SubGHz app to be listed before the other apps, but this change can stay as is.