### PR TITLE
Main Menu for Dummy Mode/Games Mode

### DIFF
--- a/applications/services/desktop/scenes/desktop_scene_main.c
+++ b/applications/services/desktop/scenes/desktop_scene_main.c
@@ -14,7 +14,6 @@
 #define TAG "DesktopSrv"
 
 #define CLOCK_APP EXT_PATH("apps/Main/dab_timer.fap")
-#define DICE_APP EXT_PATH("apps/Games/dice.fap")
 #define DOOM_APP EXT_PATH("apps/Games/doom.fap")
 #define HEAP_DEFENCE_APP EXT_PATH("apps/Games/heap_defence.fap")
 #define IMPROVED_2048_APP EXT_PATH("apps/Games/2048_improved.fap")
@@ -217,10 +216,6 @@ bool desktop_scene_main_on_event(void* context, SceneManagerEvent event) {
         }
         case DesktopMainEventOpenDOOM: {
             desktop_scene_main_open_app_or_profile(desktop, DOOM_APP);
-            break;
-        }
-        case DesktopMainEventOpenDice: {
-            desktop_scene_main_open_app_or_profile(desktop, DICE_APP);
             break;
         }
         case DesktopMainEventOpenHeap: {

--- a/applications/services/desktop/scenes/desktop_scene_main.c
+++ b/applications/services/desktop/scenes/desktop_scene_main.c
@@ -126,6 +126,13 @@ bool desktop_scene_main_on_event(void* context, SceneManagerEvent event) {
             consumed = true;
         } break;
 
+        case DesktopMainEventOpenGamesMenu: {
+            Loader* loader = furi_record_open(RECORD_LOADER);
+            loader_show_gamesmenu(loader);
+            furi_record_close(RECORD_LOADER);
+            consumed = true;
+        } break;
+
         case DesktopMainEventOpenLockMenu:
             scene_manager_next_scene(desktop->scene_manager, DesktopSceneLockMenu);
             consumed = true;

--- a/applications/services/desktop/views/desktop_events.h
+++ b/applications/services/desktop/views/desktop_events.h
@@ -19,7 +19,6 @@ typedef enum {
     DesktopMainEventOpenZombiez,
     DesktopMainEventOpenTetris,
     DesktopMainEventOpenDOOM,
-    DesktopMainEventOpenDice,
     DesktopMainEventOpenHeap,
     DesktopMainEventOpenJetPack,
     DesktopMainEventOpenClock,

--- a/applications/services/desktop/views/desktop_events.h
+++ b/applications/services/desktop/views/desktop_events.h
@@ -8,7 +8,7 @@ typedef enum {
     DesktopMainEventOpenFavoriteTertiary,
     DesktopMainEventOpenFavoriteQuaternary,
     DesktopMainEventOpenMenu,
-    DesktopMainEventOpenGames,
+    DesktopMainEventOpenGamesMenu,
     DesktopMainEventOpenDebug,
     DesktopMainEventOpenPassport,
     DesktopMainEventOpenPowerOff,

--- a/applications/services/desktop/views/desktop_view_main.c
+++ b/applications/services/desktop/views/desktop_view_main.c
@@ -92,14 +92,13 @@ bool desktop_main_input_callback(InputEvent* event, void* context) {
             if(event->key == InputKeyOk) {
                 main_view->callback(
                     DesktopMainEventOpenGamesMenu, main_view->context); // OPENS GamesMenu
-                //main_view->callback(DesktopMainEventOpenJetPack, main_view->context); // OPENS JETPACK
             } else if(event->key == InputKeyUp) {
                 main_view->callback(DesktopMainEventOpenSnake, main_view->context); // OPENS SNAKE
             } else if(event->key == InputKeyDown) {
                 main_view->callback(
                     DesktopMainEventOpenTetris, main_view->context); // OPENS TETRIS
             } else if(event->key == InputKeyLeft) {
-                main_view->callback(DesktopMainEventOpenDice, main_view->context); // OPENS Dice
+                main_view->callback(DesktopMainEventOpenJetPack, main_view->context); // OPENS JETPACK
             }
         } else if(event->type == InputTypeLong) {
             if(event->key == InputKeyOk) {
@@ -120,14 +119,13 @@ bool desktop_main_input_callback(InputEvent* event, void* context) {
             if(event->key == InputKeyOk) {
                 main_view->callback(
                     DesktopMainEventOpenGamesMenu, main_view->context); // OPENS GamesMenu
-                //main_view->callback(DesktopMainEventOpenJetPack, main_view->context); // OPENS JETPACK
             } else if(event->key == InputKeyUp) {
                 main_view->callback(DesktopMainEventOpenLockMenu, main_view->context);
             } else if(event->key == InputKeyDown) {
                 main_view->callback(
                     DesktopMainEventOpenTetris, main_view->context); // OPENS Tetris
             } else if(event->key == InputKeyLeft) {
-                main_view->callback(DesktopMainEventOpenDice, main_view->context); // OPENS Dice
+                main_view->callback(DesktopMainEventOpenJetPack, main_view->context); // OPENS JETPACK
             }
         } else if(event->type == InputTypeLong) {
             if(event->key == InputKeyOk) {

--- a/applications/services/desktop/views/desktop_view_main.c
+++ b/applications/services/desktop/views/desktop_view_main.c
@@ -91,8 +91,8 @@ bool desktop_main_input_callback(InputEvent* event, void* context) {
         if(event->type == InputTypeShort) {
             if(event->key == InputKeyOk) {
                 main_view->callback(
-                    DesktopMainEventOpenJetPack,
-                    main_view->context); // OPENS JETPACK
+                    DesktopMainEventOpenGamesMenu, main_view->context); // OPENS GamesMenu
+                //main_view->callback(DesktopMainEventOpenJetPack, main_view->context); // OPENS JETPACK
             } else if(event->key == InputKeyUp) {
                 main_view->callback(DesktopMainEventOpenSnake, main_view->context); // OPENS SNAKE
             } else if(event->key == InputKeyDown) {
@@ -119,8 +119,8 @@ bool desktop_main_input_callback(InputEvent* event, void* context) {
         if(event->type == InputTypeShort) {
             if(event->key == InputKeyOk) {
                 main_view->callback(
-                    DesktopMainEventOpenJetPack,
-                    main_view->context); // OPENS JETPACK
+                    DesktopMainEventOpenGamesMenu, main_view->context); // OPENS GamesMenu
+                //main_view->callback(DesktopMainEventOpenJetPack, main_view->context); // OPENS JETPACK
             } else if(event->key == InputKeyUp) {
                 main_view->callback(DesktopMainEventOpenLockMenu, main_view->context);
             } else if(event->key == InputKeyDown) {

--- a/applications/services/loader/loader.h
+++ b/applications/services/loader/loader.h
@@ -77,6 +77,12 @@ bool loader_is_locked(Loader* instance);
 void loader_show_menu(Loader* instance);
 
 /**
+ * @brief Show loader gamesmenu
+ * @param[in] instance loader instance
+ */
+void loader_show_gamesmenu(Loader* instance);
+
+/**
  * @brief Get loader pubsub
  * @param[in] instance loader instance
  * @return FuriPubSub* 
@@ -84,6 +90,8 @@ void loader_show_menu(Loader* instance);
 FuriPubSub* loader_get_pubsub(Loader* instance);
 
 MainMenuList_t* loader_get_mainmenu_apps(Loader* loader);
+
+GamesMenuList_t* loader_get_gamesmenu_apps(Loader* loader);
 
 #ifdef __cplusplus
 }

--- a/applications/services/loader/loader_i.h
+++ b/applications/services/loader/loader_i.h
@@ -2,6 +2,7 @@
 #include <furi.h>
 #include <toolbox/api_lock.h>
 #include <flipper_application/flipper_application.h>
+#include <m-array.h>
 #include "loader.h"
 #include "loader_menu.h"
 #include "loader_mainmenu.h"
@@ -21,12 +22,14 @@ struct Loader {
     LoaderApplications* loader_applications;
     LoaderAppData app;
     MainMenuList_t mainmenu_apps;
+    GamesMenuList_t gamesmenu_apps;
 };
 
 typedef enum {
     LoaderMessageTypeStartByName,
     LoaderMessageTypeAppClosed,
     LoaderMessageTypeShowMenu,
+    LoaderMessageTypeShowGamesMenu,
     LoaderMessageTypeMenuClosed,
     LoaderMessageTypeApplicationsClosed,
     LoaderMessageTypeLock,

--- a/applications/services/loader/loader_mainmenu.h
+++ b/applications/services/loader/loader_mainmenu.h
@@ -10,3 +10,11 @@ typedef struct {
 } MainMenuApp;
 
 LIST_DEF(MainMenuList, MainMenuApp, M_POD_OPLIST)
+
+typedef struct {
+    const char* name;
+    const char* path;
+    const Icon* icon;
+} GamesMenuApp;
+
+LIST_DEF(GamesMenuList, GamesMenuApp, M_POD_OPLIST)

--- a/applications/services/loader/loader_menu.h
+++ b/applications/services/loader/loader_menu.h
@@ -9,6 +9,8 @@ typedef struct LoaderMenu LoaderMenu;
 
 LoaderMenu* loader_menu_alloc(void (*closed_cb)(void*), void* context);
 
+LoaderMenu* loader_gamesmenu_alloc(void (*closed_cb)(void*), void* context);
+
 void loader_menu_free(LoaderMenu* loader_menu);
 
 #ifdef __cplusplus

--- a/firmware/targets/f7/api_symbols.csv
+++ b/firmware/targets/f7/api_symbols.csv
@@ -1,5 +1,5 @@
 entry,status,name,type,params
-Version,+,34.4,,
+Version,+,34.5,,
 Header,+,applications/drivers/subghz/cc1101_ext/cc1101_ext_interconnect.h,,
 Header,+,applications/services/bt/bt_service/bt.h,,
 Header,+,applications/services/cli/cli.h,,
@@ -1941,10 +1941,12 @@ Function,-,llrintl,long long int,long double
 Function,-,llround,long long int,double
 Function,-,llroundf,long long int,float
 Function,-,llroundl,long long int,long double
+Function,+,loader_get_gamesmenu_apps,GamesMenuList_t*,Loader*
 Function,+,loader_get_mainmenu_apps,MainMenuList_t*,Loader*
 Function,+,loader_get_pubsub,FuriPubSub*,Loader*
 Function,+,loader_is_locked,_Bool,Loader*
 Function,+,loader_lock,_Bool,Loader*
+Function,+,loader_show_gamesmenu,void,Loader*
 Function,+,loader_show_menu,void,Loader*
 Function,+,loader_start,LoaderStatus,"Loader*, const char*, const char*, FuriString*"
 Function,+,loader_start_with_gui_error,LoaderStatus,"Loader*, const char*, const char*"

--- a/lib/cfw/cfw.h
+++ b/lib/cfw/cfw.h
@@ -11,6 +11,7 @@ extern "C" {
 
 #define CFW_SETTINGS_PATH CFG_PATH("cfw_settings.txt")
 #define CFW_MENU_PATH CFG_PATH("cfw_mainmenu.txt")
+#define CFW_MENU_GAMESMODE_PATH CFG_PATH("cfw_gamesmenu.txt")
 #define CFW_APPS_PATH CFW_MENU_PATH
 #define NAMESPOOF_HEADER "Flipper Name File"
 #define NAMESPOOF_VERSION 1


### PR DESCRIPTION
- On boot, `Loader` will populate the Games Menu from the `/ext/.config/cfw_gamesmenu.txt` file (similar to Main Menu)
- If `cfw_gamesmenu.txt` doesn't exist, `Loader` will grab all `.fap` files within the `/ext/apps/Games` folder and create the `cfw_gamesmenu.txt` file
- `cfw_gamesmenu.txt` file doesn't auto-update when more games are put into the `/ext/apps/Games` folder
  - To regenerate the list, simply delete the `/ext/.config/cfw_gamesmenu.txt` file and reboot the FlipperZero
- In the case of an empty menu being generated, two default apps (Dice and Snake) are manually added
- The list is maxed out at 128 entries as I'm unsure if there's a limit before crashing occurs