### PR TITLE
Fixed Memory leak/Pointer issue with CFW Settings app

### DIFF
--- a/applications/settings/cfw_app/cfw_app.c
+++ b/applications/settings/cfw_app/cfw_app.c
@@ -188,8 +188,8 @@ CfwApp* cfw_app_alloc() {
 
     for(size_t i = 0; i < MainMenuList_size(*mainmenu_apps); i++) {
         const MainMenuApp* menu_item = MainMenuList_get(*mainmenu_apps, i);
-        CharList_push_back(app->mainmenu_app_names, (char*)menu_item->name);
-        CharList_push_back(app->mainmenu_app_paths, (char*)menu_item->path);
+        CharList_push_back(app->mainmenu_app_names, strdup(menu_item->name));
+        CharList_push_back(app->mainmenu_app_paths, strdup(menu_item->path));
     }
 
     Storage* storage = furi_record_open(RECORD_STORAGE);


### PR DESCRIPTION
- Issue caused added apps on main menu to stop working when user would enter and exit `CFW Settings`
- Issue also caused "blank" apps to appear
- This fixes a crash that would also occur if you entered/exited `CFW Settings` repeatedly