### PR TITLE
Small fix for Moving Main Menu Apps in CFW Settings

### DIFF
--- a/applications/settings/cfw_app/scenes/cfw_app_scene_interface_mainmenu.c
+++ b/applications/settings/cfw_app/scenes/cfw_app_scene_interface_mainmenu.c
@@ -179,7 +179,8 @@ bool cfw_app_scene_interface_mainmenu_on_event(void* context, SceneManagerEvent 
             app->save_mainmenu_apps = true;
             app->require_reboot = true;
             scene_manager_previous_scene(app->scene_manager);
-            scene_manager_set_scene_state(app->scene_manager, CfwAppSceneInterfaceMainmenu, 0);
+            scene_manager_set_scene_state(
+                app->scene_manager, CfwAppSceneInterfaceMainmenu, VarItemListIndexMoveApp);
             scene_manager_next_scene(app->scene_manager, CfwAppSceneInterfaceMainmenu);
             break;
         case VarItemListIndexAddApp:


### PR DESCRIPTION
- Issue was that when a user moved an app in CFW Settings > Interface > Main Menu, the menu would reset position back to Style item (the top item)