### PR TITLE
ESubGHz crash patch

### DIFF
--- a/applications/external/esubghz_chat/esubghz_chat.c
+++ b/applications/external/esubghz_chat/esubghz_chat.c
@@ -473,7 +473,7 @@ int32_t esubghz_chat(void) {
         goto err_alloc_hs;
     }
 
-    state->menu = submenu_alloc();
+    state->menu = menu_pos_alloc(0);
     if(state->menu == NULL) {
         goto err_alloc_menu;
     }

--- a/applications/external/esubghz_chat/esubghz_chat.c
+++ b/applications/external/esubghz_chat/esubghz_chat.c
@@ -473,7 +473,7 @@ int32_t esubghz_chat(void) {
         goto err_alloc_hs;
     }
 
-    state->menu = menu_alloc();
+    state->menu = submenu_alloc();
     if(state->menu == NULL) {
         goto err_alloc_menu;
     }


### PR DESCRIPTION
# What's new

- Fix crash caused by this change: https://github.com/RogueMaster/flipperzero-firmware-wPlugins/commit/09e65b34b80431333ec14e1b0ee2e752b6faca49#diff-43be2a86818c2f241b1cfa2d6175da82aa5cbec325b8d1a909beb773d941b141R476
- This is probably not a good permanent fix because of the new main menus (DSi, PS4, etc), it should probably be a submenu not a main menu.