### PR TITLE
Eurocorp menu style & exposed 3 more fonts in canvas

### DIFF
--- a/applications/external/chess/application.fam
+++ b/applications/external/chess/application.fam
@@ -14,6 +14,6 @@ App(
     fap_category="Games",
     fap_author="Struan Clark (xtruan)",
     fap_weburl="https://github.com/xtruan/flipper-chess",
-    fap_version=(1, 8),
+    fap_version=(1, 9),
     fap_description="Chess for Flipper",
 )

--- a/applications/external/chess/flipchess.h
+++ b/applications/external/chess/flipchess.h
@@ -16,7 +16,7 @@
 #include "views/flipchess_startscreen.h"
 #include "views/flipchess_scene_1.h"
 
-#define FLIPCHESS_VERSION "v1.8.0"
+#define FLIPCHESS_VERSION "v1.9.0"
 
 #define TEXT_BUFFER_SIZE 96
 #define TEXT_SIZE (TEXT_BUFFER_SIZE - 1)

--- a/applications/external/chess/views/flipchess_startscreen.c
+++ b/applications/external/chess/views/flipchess_startscreen.c
@@ -32,10 +32,18 @@ void flipchess_startscreen_draw(Canvas* canvas, FlipChessStartscreenModel* model
 
     canvas_draw_icon(canvas, 0, 0, &I_FLIPR_128x64);
 
+#ifdef CANVAS_HAS_FONT_SCUMM_ROMAN_OUTLINE
+    const uint8_t text_x_pos = 2;
+    const uint8_t text_y_pos = 12;
+    canvas_set_font(canvas, FontScummRomanOutline);
+#else
+    const uint8_t text_x_pos = 4;
+    const uint8_t text_y_pos = 11;
     canvas_set_font(canvas, FontPrimary);
-    canvas_draw_str(canvas, 4, 11, "Chess");
+#endif
+    canvas_draw_str(canvas, text_x_pos, text_y_pos, "Chess");
     canvas_set_font(canvas, FontSecondary);
-    canvas_draw_str(canvas, 62, 11, FLIPCHESS_VERSION);
+    canvas_draw_str(canvas, 62, text_y_pos, FLIPCHESS_VERSION);
 
     //canvas_set_font(canvas, FontSecondary);
     //canvas_draw_str(canvas, 10, 11, "How about a nice game of...");

--- a/applications/services/gui/canvas.c
+++ b/applications/services/gui/canvas.c
@@ -15,6 +15,10 @@ const CanvasFontParameters canvas_font_params[FontTotalNumber] = {
     [FontKeyboard] = {.leading_default = 11, .leading_min = 9, .height = 7, .descender = 2},
     [FontBigNumbers] = {.leading_default = 18, .leading_min = 16, .height = 15, .descender = 0},
     [FontBatteryPercent] = {.leading_default = 11, .leading_min = 9, .height = 6, .descender = 0},
+    [FontScummRomanOutline] =
+        {.leading_default = 12, .leading_min = 11, .height = 12, .descender = 2},
+    [FontScummRoman] = {.leading_default = 12, .leading_min = 11, .height = 10, .descender = 2},
+    [FontEurocorp] = {.leading_default = 12, .leading_min = 11, .height = 16, .descender = 2},
 };
 
 Canvas* canvas_init() {
@@ -160,6 +164,15 @@ void canvas_set_font(Canvas* canvas, Font font) {
         break;
     case FontBatteryPercent:
         u8g2_SetFont(&canvas->fb, u8g2_font_5x7_tf); //u8g2_font_micro_tr);
+        break;
+    case FontScummRomanOutline:
+        u8g2_SetFont(&canvas->fb, u8g2_font_lucasarts_scumm_subtitle_o_tr);
+        break;
+    case FontScummRoman:
+        u8g2_SetFont(&canvas->fb, u8g2_font_lucasarts_scumm_subtitle_r_tr);
+        break;
+    case FontEurocorp:
+        u8g2_SetFont(&canvas->fb, u8g2_font_eurocorp_tr);
         break;
     default:
         furi_crash(NULL);

--- a/applications/services/gui/canvas.h
+++ b/applications/services/gui/canvas.h
@@ -20,6 +20,11 @@ typedef enum {
     ColorXOR = 0x02,
 } Color;
 
+/** Provide defines to permit checking if new are fonts available*/
+#define CANVAS_HAS_FONT_SCUMM_ROMAN_OUTLINE = 1
+#define CANVAS_HAS_FONT_SCUMM_ROMAN = 1
+#define CANVAS_HAS_FONT_EUROCORP = 1
+
 /** Fonts enumeration */
 typedef enum {
     FontPrimary,
@@ -27,6 +32,9 @@ typedef enum {
     FontKeyboard,
     FontBigNumbers,
     FontBatteryPercent,
+    FontScummRomanOutline,
+    FontScummRoman,
+    FontEurocorp,
 
     // Keep last for fonts number calculation
     FontTotalNumber,

--- a/applications/settings/cfw_app/scenes/cfw_app_scene_interface_mainmenu.c
+++ b/applications/settings/cfw_app/scenes/cfw_app_scene_interface_mainmenu.c
@@ -22,6 +22,7 @@ const char* const menu_style_names[MenuStyleCount] = {
     "PS4",
     "Vertical",
     "C64",
+    "Eurocorp",
 };
 static void cfw_app_scene_interface_mainmenu_menu_style_changed(VariableItem* item) {
     CfwApp* app = variable_item_get_context(item);

--- a/lib/cfw/cfw.h
+++ b/lib/cfw/cfw.h
@@ -24,6 +24,7 @@ typedef enum {
     MenuStylePs4,
     MenuStyleVertical,
     MenuStyleC64,
+    MenuStyleEurocorp,
     MenuStyleCount,
 } MenuStyle;
 

--- a/lib/u8g2/u8g2.h
+++ b/lib/u8g2/u8g2.h
@@ -5813,6 +5813,7 @@ extern const uint8_t u8g2_font_px437wyse700b_tn[] U8G2_FONT_SECTION("u8g2_font_p
 extern const uint8_t u8g2_font_px437wyse700b_mf[] U8G2_FONT_SECTION("u8g2_font_px437wyse700b_mf");
 extern const uint8_t u8g2_font_px437wyse700b_mr[] U8G2_FONT_SECTION("u8g2_font_px437wyse700b_mr");
 extern const uint8_t u8g2_font_px437wyse700b_mn[] U8G2_FONT_SECTION("u8g2_font_px437wyse700b_mn");
+extern const uint8_t u8g2_font_eurocorp_tr[] U8G2_FONT_SECTION("u8g2_font_eurocorp_tr");
 
 /* end font list */
 


### PR DESCRIPTION
# What's new

- Added Eurocorp cyberpunk main menu inspired by this: http://syndicate.lubiki.pl/swars/gallery/swars_photos_inmenu_pc.php
- Exposed 3 more fonts from u8g2 via canvas (including newly added Eurocorp font)
  - This *seems* safe enough, but I might be missing something. Main concern is that if it's so easy to do, and the fonts are already there, why doesn't OFW or any CFW provide more font options...

# Verification 

- New Eurocorp menu in CFW settings app
- Start screen for Chess using outline font

# Checklist (For Reviewer)

- [X] PR has description of feature/bug
- [X] Description contains actions to verify feature/bugfix
- [X] I've built this code, uploaded it to the device and verified feature/bugfix
