### PR TITLE
CFW Settings > Misc > Screen updates

### DIFF
--- a/applications/settings/cfw_app/scenes/cfw_app_scene_misc_screen.c
+++ b/applications/settings/cfw_app/scenes/cfw_app_scene_misc_screen.c
@@ -4,6 +4,8 @@ enum VarItemListIndex {
     VarItemListIndexDarkMode,
     VarItemListIndexLeftHanded,
     VarItemListIndexRgbBacklight,
+    VarItemListIndexLcdStyle,
+    VarItemListIndexLcdStaticColor,
     VarItemListIndexLcdColor0,
     VarItemListIndexLcdColor1,
     VarItemListIndexLcdColor2,
@@ -40,41 +42,77 @@ static const struct {
     char* name;
     RgbColor color;
 } lcd_colors[] = {
-    {"Orange", {255, 60, 0}},
-    {"Red", {255, 0, 0}},
-    {"Maroon", {128, 0, 0}},
-    {"Yellow", {255, 150, 0}},
-    {"Olive", {128, 128, 0}},
-    {"Lime", {0, 255, 0}},
-    {"Green", {0, 128, 0}},
-    {"Aqua", {0, 255, 127}},
-    {"Cyan", {0, 210, 210}},
-    {"Azure", {0, 127, 255}},
-    {"Teal", {0, 128, 128}},
-    {"Blue", {0, 0, 255}},
-    {"Navy", {0, 0, 128}},
-    {"Purple", {128, 0, 255}},
-    {"Fuchsia", {255, 0, 255}},
-    {"Pink", {255, 0, 127}},
-    {"Brown", {165, 42, 42}},
-    {"White", {150, 150, 110}},
+    {"Orange", {255, 60, 0}},  {"Red", {255, 0, 0}},      {"Maroon", {128, 0, 0}},
+    {"Yellow", {255, 150, 0}}, {"Olive", {128, 128, 0}},  {"Lime", {0, 255, 0}},
+    {"Green", {0, 128, 0}},    {"Aqua", {0, 255, 127}},   {"Cyan", {0, 210, 210}},
+    {"Azure", {0, 127, 255}},  {"Teal", {0, 128, 128}},   {"Blue", {0, 0, 255}},
+    {"Navy", {0, 0, 128}},     {"Purple", {128, 0, 255}}, {"Fuchsia", {255, 0, 255}},
+    {"Pink", {255, 0, 127}},   {"Brown", {165, 42, 42}},  {"White", {150, 150, 110}},
+    {"Off", {0, 0, 0}},
 };
 
+const char* const lcd_styles[] = {
+    "Static",
+    "Custom",
+    "Rainbow",
+};
+
+static void cfw_app_scene_misc_screen_lcd_style_changed(VariableItem* item) {
+    CfwApp* app = variable_item_get_context(item);
+    uint32_t value = variable_item_get_current_value_index(item);
+    variable_item_set_current_value_text(item, lcd_styles[value]);
+    CFW_SETTINGS()->lcd_style = value;
+
+    switch(value) {
+    case 0:
+    case 1:
+        notification_message(app->notification, &sequence_display_backlight_off);
+        rgb_backlight_set_rainbow_mode(0);
+        rgb_backlight_set_color(0, lcd_colors[0].color);
+        rgb_backlight_set_color(1, lcd_colors[0].color);
+        rgb_backlight_set_color(2, lcd_colors[0].color);
+        notification_message(app->notification, &sequence_display_backlight_on);
+        break;
+    case 2:
+    default:
+        break;
+    }
+    app->save_backlight = true;
+    app->save_settings = true;
+    scene_manager_previous_scene(app->scene_manager);
+    scene_manager_set_scene_state(
+        app->scene_manager, CfwAppSceneMiscScreen, VarItemListIndexLcdStyle);
+    scene_manager_next_scene(app->scene_manager, CfwAppSceneMiscScreen);
+}
+
+static void cfw_app_scene_misc_screen_lcd_static_color_changed(VariableItem* item) {
+    CfwApp* app = variable_item_get_context(item);
+    uint8_t index = variable_item_get_current_value_index(item);
+    variable_item_set_current_value_text(item, lcd_colors[index].name);
+    notification_message(app->notification, &sequence_display_backlight_off);
+    rgb_backlight_set_color(0, lcd_colors[index].color);
+    rgb_backlight_set_color(1, lcd_colors[index].color);
+    rgb_backlight_set_color(2, lcd_colors[index].color);
+    notification_message(app->notification, &sequence_display_backlight_on);
+    app->save_backlight = true;
+}
 static void cfw_app_scene_misc_screen_lcd_color_changed(VariableItem* item, uint8_t led) {
     CfwApp* app = variable_item_get_context(item);
     uint8_t index = variable_item_get_current_value_index(item);
     variable_item_set_current_value_text(item, lcd_colors[index].name);
+    notification_message(app->notification, &sequence_display_backlight_off);
     rgb_backlight_set_color(led, lcd_colors[index].color);
+    notification_message(app->notification, &sequence_display_backlight_on);
     app->save_backlight = true;
 }
 static void cfw_app_scene_misc_screen_lcd_color_0_changed(VariableItem* item) {
-    cfw_app_scene_misc_screen_lcd_color_changed(item, 0);
+    cfw_app_scene_misc_screen_lcd_color_changed(item, 2);
 }
 static void cfw_app_scene_misc_screen_lcd_color_1_changed(VariableItem* item) {
     cfw_app_scene_misc_screen_lcd_color_changed(item, 1);
 }
 static void cfw_app_scene_misc_screen_lcd_color_2_changed(VariableItem* item) {
-    cfw_app_scene_misc_screen_lcd_color_changed(item, 2);
+    cfw_app_scene_misc_screen_lcd_color_changed(item, 0);
 }
 
 const char* const rainbow_lcd_names[RGBBacklightRainbowModeCount] = {
@@ -171,84 +209,136 @@ void cfw_app_scene_misc_screen_on_enter(void* context) {
     item = variable_item_list_add(var_item_list, "RGB Backlight", 1, NULL, app);
     variable_item_set_current_value_text(item, cfw_settings->rgb_backlight ? "ON" : "OFF");
 
-    struct {
-        uint8_t led;
-        const char* str;
-        VariableItemChangeCallback cb;
-    } lcd_cols[] = {
-        {0, "LCD Left", cfw_app_scene_misc_screen_lcd_color_0_changed},
-        {1, "LCD Middle", cfw_app_scene_misc_screen_lcd_color_1_changed},
-        {2, "LCD Right", cfw_app_scene_misc_screen_lcd_color_2_changed},
-    };
-    size_t lcd_sz = COUNT_OF(lcd_colors);
+    if(cfw_settings->rgb_backlight) {
+        item = variable_item_list_add(
+            var_item_list,
+            "LCD Style",
+            COUNT_OF(lcd_styles),
+            cfw_app_scene_misc_screen_lcd_style_changed,
+            app);
+        variable_item_set_current_value_index(item, cfw_settings->lcd_style);
+        variable_item_set_current_value_text(item, lcd_styles[cfw_settings->lcd_style]);
 
-    for(size_t i = 0; i < COUNT_OF(lcd_cols); i++) {
-        item = variable_item_list_add(var_item_list, lcd_cols[i].str, lcd_sz, lcd_cols[i].cb, app);
-        RgbColor color = rgb_backlight_get_color(lcd_cols[i].led);
-        bool found = false;
-        for(size_t i = 0; i < lcd_sz; i++) {
-            if(rgbcmp(&color, &lcd_colors[i].color) != 0) continue;
-            value_index = i;
-            found = true;
+        size_t lcd_sz = COUNT_OF(lcd_colors);
+
+        struct {
+            uint8_t led;
+            const char* str;
+            VariableItemChangeCallback cb;
+        } lcd_cols[] = {
+            {2, "LCD Left", cfw_app_scene_misc_screen_lcd_color_0_changed},
+            {1, "LCD Middle", cfw_app_scene_misc_screen_lcd_color_1_changed},
+            {0, "LCD Right", cfw_app_scene_misc_screen_lcd_color_2_changed},
+        };
+
+        switch(cfw_settings->lcd_style) {
+        case 0:
+            item = variable_item_list_add(
+                var_item_list,
+                "LCD Color",
+                lcd_sz,
+                cfw_app_scene_misc_screen_lcd_static_color_changed,
+                app);
+            RgbColor color = rgb_backlight_get_color(0);
+            bool found = false;
+            for(size_t i = 0; i < lcd_sz; i++) {
+                if(rgbcmp(&color, &lcd_colors[i].color) != 0) continue;
+                value_index = i;
+                found = true;
+                break;
+            }
+
+            variable_item_set_current_value_index(item, found ? value_index : lcd_sz);
+            if(found) {
+                variable_item_set_current_value_text(item, lcd_colors[value_index].name);
+            } else {
+                char str[7];
+                snprintf(str, sizeof(str), "%02X%02X%02X", color.r, color.g, color.b);
+                variable_item_set_current_value_text(item, str);
+            }
+
+            variable_item_set_locked(item, !cfw_settings->rgb_backlight, "Needs RGB\nBacklight!");
+            break;
+        case 1:
+            for(size_t i = 0; i < COUNT_OF(lcd_cols); i++) {
+                item = variable_item_list_add(
+                    var_item_list, lcd_cols[i].str, lcd_sz, lcd_cols[i].cb, app);
+                RgbColor color = rgb_backlight_get_color(lcd_cols[i].led);
+                bool found = false;
+                for(size_t i = 0; i < lcd_sz; i++) {
+                    if(rgbcmp(&color, &lcd_colors[i].color) != 0) continue;
+                    value_index = i;
+                    found = true;
+                    break;
+                }
+                variable_item_set_current_value_index(item, found ? value_index : lcd_sz);
+                if(found) {
+                    variable_item_set_current_value_text(item, lcd_colors[value_index].name);
+                } else {
+                    char str[7];
+                    snprintf(str, sizeof(str), "%02X%02X%02X", color.r, color.g, color.b);
+                    variable_item_set_current_value_text(item, str);
+                }
+                variable_item_set_locked(
+                    item, !cfw_settings->rgb_backlight, "Needs RGB\nBacklight!");
+            }
+            break;
+        case 2:
+            item = variable_item_list_add(
+                var_item_list,
+                "Rainbow LCD",
+                RGBBacklightRainbowModeCount,
+                cfw_app_scene_misc_screen_rainbow_lcd_changed,
+                app);
+            value_index = rgb_backlight_get_rainbow_mode();
+            variable_item_set_current_value_index(item, value_index);
+            variable_item_set_current_value_text(item, rainbow_lcd_names[value_index]);
+            variable_item_set_locked(item, !cfw_settings->rgb_backlight, "Needs RGB\nBacklight!");
+
+            item = variable_item_list_add(
+                var_item_list,
+                "Rainbow Speed",
+                25,
+                cfw_app_scene_misc_screen_rainbow_speed_changed,
+                app);
+            value_index = rgb_backlight_get_rainbow_speed();
+            variable_item_set_current_value_index(item, value_index - 1);
+            char speed_str[4];
+            snprintf(speed_str, sizeof(speed_str), "%d", value_index);
+            variable_item_set_current_value_text(item, speed_str);
+            variable_item_set_locked(item, !cfw_settings->rgb_backlight, "Needs RGB\nBacklight!");
+
+            item = variable_item_list_add(
+                var_item_list,
+                "Rainbow Interval",
+                COUNT_OF(rainbow_interval_values),
+                cfw_app_scene_misc_screen_rainbow_interval_changed,
+                app);
+            value_index = value_index_uint32(
+                rgb_backlight_get_rainbow_interval(),
+                rainbow_interval_values,
+                COUNT_OF(rainbow_interval_values));
+            variable_item_set_current_value_index(item, value_index);
+            variable_item_set_current_value_text(item, rainbow_interval_names[value_index]);
+            variable_item_set_locked(item, !cfw_settings->rgb_backlight, "Needs RGB\nBacklight!");
+
+            item = variable_item_list_add(
+                var_item_list,
+                "Rainbow Saturation",
+                255,
+                cfw_app_scene_misc_screen_rainbow_saturation_changed,
+                app);
+            value_index = rgb_backlight_get_rainbow_saturation();
+            variable_item_set_current_value_index(item, value_index - 1);
+            char saturation_str[4];
+            snprintf(saturation_str, sizeof(saturation_str), "%d", value_index);
+            variable_item_set_current_value_text(item, saturation_str);
+            variable_item_set_locked(item, !cfw_settings->rgb_backlight, "Needs RGB\nBacklight!");
+            break;
+        default:
             break;
         }
-        variable_item_set_current_value_index(item, found ? value_index : lcd_sz);
-        if(found) {
-            variable_item_set_current_value_text(item, lcd_colors[value_index].name);
-        } else {
-            char str[7];
-            snprintf(str, sizeof(str), "%02X%02X%02X", color.r, color.g, color.b);
-            variable_item_set_current_value_text(item, str);
-        }
-        variable_item_set_locked(item, !cfw_settings->rgb_backlight, "Needs RGB\nBacklight!");
     }
-
-    item = variable_item_list_add(
-        var_item_list,
-        "Rainbow LCD",
-        RGBBacklightRainbowModeCount,
-        cfw_app_scene_misc_screen_rainbow_lcd_changed,
-        app);
-    value_index = rgb_backlight_get_rainbow_mode();
-    variable_item_set_current_value_index(item, value_index);
-    variable_item_set_current_value_text(item, rainbow_lcd_names[value_index]);
-    variable_item_set_locked(item, !cfw_settings->rgb_backlight, "Needs RGB\nBacklight!");
-
-    item = variable_item_list_add(
-        var_item_list, "Rainbow Speed", 25, cfw_app_scene_misc_screen_rainbow_speed_changed, app);
-    value_index = rgb_backlight_get_rainbow_speed();
-    variable_item_set_current_value_index(item, value_index - 1);
-    char speed_str[4];
-    snprintf(speed_str, sizeof(speed_str), "%d", value_index);
-    variable_item_set_current_value_text(item, speed_str);
-    variable_item_set_locked(item, !cfw_settings->rgb_backlight, "Needs RGB\nBacklight!");
-
-    item = variable_item_list_add(
-        var_item_list,
-        "Rainbow Interval",
-        COUNT_OF(rainbow_interval_values),
-        cfw_app_scene_misc_screen_rainbow_interval_changed,
-        app);
-    value_index = value_index_uint32(
-        rgb_backlight_get_rainbow_interval(),
-        rainbow_interval_values,
-        COUNT_OF(rainbow_interval_values));
-    variable_item_set_current_value_index(item, value_index);
-    variable_item_set_current_value_text(item, rainbow_interval_names[value_index]);
-    variable_item_set_locked(item, !cfw_settings->rgb_backlight, "Needs RGB\nBacklight!");
-
-    item = variable_item_list_add(
-        var_item_list,
-        "Rainbow Saturation",
-        160,
-        cfw_app_scene_misc_screen_rainbow_saturation_changed,
-        app);
-    value_index = rgb_backlight_get_rainbow_saturation();
-    variable_item_set_current_value_index(item, value_index - 1);
-    char saturation_str[4];
-    snprintf(saturation_str, sizeof(saturation_str), "%d", value_index);
-    variable_item_set_current_value_text(item, saturation_str);
-    variable_item_set_locked(item, !cfw_settings->rgb_backlight, "Needs RGB\nBacklight!");
 
     variable_item_list_set_enter_callback(
         var_item_list, cfw_app_scene_misc_screen_var_item_list_callback, app);
@@ -296,13 +386,14 @@ bool cfw_app_scene_misc_screen_on_event(void* context, SceneManagerEvent event) 
             }
             break;
         }
+        case VarItemListIndexLcdStaticColor:
         case VarItemListIndexLcdColor0:
         case VarItemListIndexLcdColor1:
         case VarItemListIndexLcdColor2:
             scene_manager_set_scene_state(
                 app->scene_manager,
                 CfwAppSceneMiscScreenColor,
-                event.event - VarItemListIndexLcdColor0);
+                event.event - VarItemListIndexLcdStaticColor);
             scene_manager_next_scene(app->scene_manager, CfwAppSceneMiscScreenColor);
             break;
         default:

--- a/lib/cfw/cfw.h
+++ b/lib/cfw/cfw.h
@@ -53,6 +53,7 @@ typedef struct {
     UARTChannel uart_nmea_channel;
     UARTChannel uart_general_channel;
     bool rgb_backlight;
+	uint32_t lcd_style;
 } CfwSettings;
 
 void CFW_SETTINGS_SAVE();

--- a/lib/cfw/settings.c
+++ b/lib/cfw/settings.c
@@ -19,6 +19,7 @@ CfwSettings cfw_settings = {
     .uart_nmea_channel = UARTDefault, // pin 13,14
     .uart_general_channel = UARTDefault, // pin 13,14
     .rgb_backlight = false, // OFF
+    .lcd_style = 0, // Static
 };
 
 void CFW_SETTINGS_LOAD() {
@@ -53,6 +54,8 @@ void CFW_SETTINGS_LOAD() {
             file, "uart_general_channel", (uint32_t*)&x->uart_general_channel, 1);
         flipper_format_rewind(file);
         flipper_format_read_bool(file, "rgb_backlight", &x->rgb_backlight, 1);
+        flipper_format_rewind(file);
+        flipper_format_read_uint32(file, "lcd_style", (uint32_t*)&x->lcd_style, 1);
     }
     flipper_format_free(file);
     furi_record_close(RECORD_STORAGE);
@@ -87,6 +90,7 @@ void CFW_SETTINGS_SAVE() {
         flipper_format_write_uint32(
             file, "uart_general_channel", (uint32_t*)&x->uart_general_channel, 1);
         flipper_format_write_bool(file, "rgb_backlight", &x->rgb_backlight, 1);
+        flipper_format_write_uint32(file, "lcd_style", (uint32_t*)&x->lcd_style, 1);
     }
     flipper_format_free(file);
     furi_record_close(RECORD_STORAGE);


### PR DESCRIPTION
### CFW Settings > Misc > Screen updates
- Made screen options a bit neater
  - Added a LCD Style setting to help with this
  - Show/Hide options that weren't required per the LCD Style setting
- Fixed an issue where color was changed but not all LEDs were updated
- Fixed an issue where `LCD Left` was changing the right LED, and `LCD Right` was changing the left LED
- Added an `Off` color option for interesting custom LED gradients
- LCD Style variable is pushed to `cfw_settings.txt`
