### PR TITLE
VSCode is optional

### DIFF
--- a/documentation/HowToBuild.md
+++ b/documentation/HowToBuild.md
@@ -8,7 +8,7 @@
 For development:
 
 - Git
-- VSCode
+- VSCode (Optional)
 
 ## Clone the Repository
 
@@ -17,7 +17,7 @@ You should clone with
 ```shell
 git clone --recursive https://github.com/RogueMaster/flipperzero-firmware-wPlugins.git
 ```
-## VSCode integration
+## VSCode integration (Optional)
 
 `fbt` includes basic development environment configuration for VS Code. Run `./fbt vscode_dist` to deploy it. That will copy the initial environment configuration to the `.vscode` folder. After that, you can use that configuration by starting VS Code and choosing the firmware root folder in the "File > Open Folder" menu.
 


### PR DESCRIPTION
VSCode integration isn't required to build the firmware

# What's new

Changed to say that VSCode is optional

# Verification 

[N/A]

# Checklist (For Reviewer)

- [*] PR has description of feature/bug
- [N/A] Description contains actions to verify feature/bugfix
- [N/A] I've built this code, uploaded it to the device and verified feature/bugfix
