### PR TITLE
Spell out RM once in RoadMap.md

### DIFF
--- a/RoadMap.md
+++ b/RoadMap.md
@@ -1,4 +1,4 @@
-# RoadMap for RM BUILD
+# RoadMap for RogueMaster (RM) BUILD
 ### This is more of a project wish list...
 - It is open to whoever wants to build and PR. You get all the credit if you can create it! :D
 - I likely won't have time to cover all these items.


### PR DESCRIPTION
# What's new

- Spell out RogueMaster before using RM abbreviation
People can get to this page straight from Google and have no idea what RM is.

# Verification 

- Just a documentation change

# Checklist (For Reviewer)

- [x ] PR has description of feature/bug
- [x ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix [unnecessary: no changes outside doc]
