### PR TITLE
fix for view port hand orientation correction if lefty mode set

### DIFF
--- a/applications/services/gui/view_port.c
+++ b/applications/services/gui/view_port.c
@@ -67,6 +67,10 @@ static void view_port_map_input(InputEvent* event, ViewPortOrientation orientati
         return;
     }
 
+    if(furi_hal_rtc_is_flag_set(FuriHalRtcFlagHandOrient)) {
+      orientation = 1;
+    }
+
     if(orientation == ViewPortOrientationHorizontal ||
        orientation == ViewPortOrientationHorizontalFlip) {
         if(furi_hal_rtc_is_flag_set(FuriHalRtcFlagHandOrient)) {


### PR DESCRIPTION
# What's new

- Patch that will make input operate to correct view port orientation in left handed mode with the inputs no longer reversed.

# Verification 

- Switch orientation to left handed mode, test up, down, left, right

# Checklist (For Reviewer)

- [ X] PR has description of feature/bug
- [ X] Description contains actions to verify feature/bugfix
- [ X] I've built this code, uploaded it to the device and verified feature/bugfix
