### PR TITLE
Fix for the NMEA GPS text overlay bug

### DIFF
--- a/applications/external/gps_nmea/gps_uart.c
+++ b/applications/external/gps_nmea/gps_uart.c
@@ -213,7 +213,7 @@ GpsUart* gps_uart_enable() {
     gps_uart->backlight_on = false;
     gps_uart->changing_baudrate = false;
     gps_uart->deep_sleep_enabled = false;
-
+    gps_uart->view_state = NORMAL;
     gps_uart_init_thread(gps_uart);
 
     return gps_uart;

--- a/applications/external/gps_nmea/gps_uart.h
+++ b/applications/external/gps_nmea/gps_uart.h
@@ -48,6 +48,7 @@ typedef struct {
     bool deep_sleep_enabled;
     bool changing_deepsleep;
 
+    ViewState view_state;
     SpeedUnit speed_units;
 
     FuriHalSerialHandle* serial_handle;

--- a/applications/external/gps_nmea/gps_uart.h
+++ b/applications/external/gps_nmea/gps_uart.h
@@ -46,6 +46,8 @@ typedef struct {
     bool backlight_on;
     bool changing_baudrate;
     bool deep_sleep_enabled;
+    bool changing_deepsleep;
+
     SpeedUnit speed_units;
 
     FuriHalSerialHandle* serial_handle;


### PR DESCRIPTION
# What's new

- Changed how the rendering called each new canvas
- Added variables for changing deep sleep mode
- Added a separated deep sleep screen so no overlay with main screens text

# Verification 

- Run the app and test deep sleep (holding down). Just running the app will show it's fixed as the screen isn't covered with text at startup.

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
