### PR TITLE
Update lfrfid_view_read.c

### DIFF
--- a/applications/main/lfrfid/views/lfrfid_view_read.c
+++ b/applications/main/lfrfid/views/lfrfid_view_read.c
@@ -23,7 +23,7 @@ static void lfrfid_view_read_draw_callback(Canvas* canvas, void* _model) {
     canvas_set_font(canvas, FontPrimary);
 
     if(model->read_mode == LfRfidReadAsk) {
-        canvas_draw_str(canvas, 70, 16, "Reading 1/2");
+        canvas_draw_str(canvas, 70, 16, "Reading 1/3");
 
         canvas_draw_str(canvas, 77, 29, "ASK");
         canvas_draw_icon(canvas, 70, 22, &I_ButtonRight_4x7);
@@ -32,7 +32,7 @@ static void lfrfid_view_read_draw_callback(Canvas* canvas, void* _model) {
         canvas_set_font(canvas, FontSecondary);
         canvas_draw_str(canvas, 77, 43, "PSK");
     } else if(model->read_mode == LfRfidReadPsk) {
-        canvas_draw_str(canvas, 70, 16, "Reading 2/2");
+        canvas_draw_str(canvas, 70, 16, "Reading 2/3");
 
         canvas_draw_str(canvas, 77, 43, "PSK");
         canvas_draw_icon(canvas, 70, 36, &I_ButtonRight_4x7);


### PR DESCRIPTION
Fix the status when looking for a card to say n/3 rather than n/2.  This issue seems to have been introduced with the RTF read was added.

# What's new

- Simply fixes the denominator of the counter when searching for a card.

# Verification 

- Start the 125 kHz RFID app and select read.  Observe the fraction after the word "Reading".  Before it would say 1/2...2/2...3/3.  Now it says 1/3...2/3...3/3

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
