### PR TITLE
Added options to lock Flipper or launch game menu to favourites

### DIFF
--- a/applications/services/desktop/scenes/desktop_scene_main.c
+++ b/applications/services/desktop/scenes/desktop_scene_main.c
@@ -245,7 +245,7 @@ bool desktop_scene_main_on_event(void* context, SceneManagerEvent event) {
                     break;
                 } else {
                     desktop_scene_main_start_favorite(
-                        desktop, &desktop->settings.favorite_apps[FavoriteAppLeftShort]);
+                        desktop, &desktop->settings.favorite_apps[FavoriteAppLeftLong]);
                 }
             }
             consumed = true;

--- a/applications/services/desktop/scenes/desktop_scene_main.c
+++ b/applications/services/desktop/scenes/desktop_scene_main.c
@@ -43,6 +43,12 @@ static void desktop_scene_main_interact_animation_callback(void* context) {
         desktop->view_dispatcher, DesktopAnimationEventInteractAnimation);
 }
 
+static void launch_games_menu() {
+    Loader* loader = furi_record_open(RECORD_LOADER);
+    loader_show_gamesmenu(loader);
+    furi_record_close(RECORD_LOADER);
+}
+
 #ifdef APP_ARCHIVE
 static void
     desktop_switch_to_app(Desktop* desktop, const FlipperInternalApplication* flipper_app) {
@@ -177,43 +183,144 @@ bool desktop_scene_main_on_event(void* context, SceneManagerEvent event) {
 
         case DesktopMainEventOpenFavoriteDownLong:
             DESKTOP_SETTINGS_LOAD(&desktop->settings);
-            desktop_scene_main_start_favorite(
-                desktop, &desktop->settings.favorite_apps[FavoriteAppDownLong]);
+            if(!desktop_scene_main_check_none(
+                   desktop->settings.favorite_apps[FavoriteAppDownLong].name_or_path)) {
+                if(!strcmp(
+                       desktop->settings.favorite_apps[FavoriteAppDownLong].name_or_path, "!L")) {
+                    scene_manager_set_scene_state(desktop->scene_manager, DesktopSceneLockMenu, 0);
+                    desktop_lock(desktop);
+                    consumed = true;
+                    break;
+                } else if(!strcmp(
+                              desktop->settings.favorite_apps[FavoriteAppDownLong].name_or_path,
+                              "!G")) {
+                    launch_games_menu();
+                    consumed = true;
+                    break;
+                } else {
+                    desktop_scene_main_start_favorite(
+                        desktop, &desktop->settings.favorite_apps[FavoriteAppDownLong]);
+                }
+            }
             consumed = true;
             break;
         case DesktopMainEventOpenFavoriteLeftShort:
             DESKTOP_SETTINGS_LOAD(&desktop->settings);
-            desktop_scene_main_start_favorite(
-                desktop, &desktop->settings.favorite_apps[FavoriteAppLeftShort]);
+            if(!desktop_scene_main_check_none(
+                   desktop->settings.favorite_apps[FavoriteAppLeftShort].name_or_path)) {
+                if(!strcmp(
+                       desktop->settings.favorite_apps[FavoriteAppLeftShort].name_or_path, "!L")) {
+                    scene_manager_set_scene_state(desktop->scene_manager, DesktopSceneLockMenu, 0);
+                    desktop_lock(desktop);
+                    consumed = true;
+                    break;
+                } else if(!strcmp(
+                              desktop->settings.favorite_apps[FavoriteAppLeftShort].name_or_path,
+                              "!G")) {
+                    launch_games_menu();
+                    consumed = true;
+                    break;
+                } else {
+                    desktop_scene_main_start_favorite(
+                        desktop, &desktop->settings.favorite_apps[FavoriteAppLeftShort]);
+                }
+            }
             consumed = true;
             break;
         case DesktopMainEventOpenFavoriteLeftLong:
             DESKTOP_SETTINGS_LOAD(&desktop->settings);
-            desktop_scene_main_start_favorite(
-                desktop, &desktop->settings.favorite_apps[FavoriteAppLeftLong]);
+            if(!desktop_scene_main_check_none(
+                   desktop->settings.favorite_apps[FavoriteAppLeftLong].name_or_path)) {
+                if(!strcmp(
+                       desktop->settings.favorite_apps[FavoriteAppLeftLong].name_or_path, "!L")) {
+                    scene_manager_set_scene_state(desktop->scene_manager, DesktopSceneLockMenu, 0);
+                    desktop_lock(desktop);
+                    consumed = true;
+                    break;
+                } else if(!strcmp(
+                              desktop->settings.favorite_apps[FavoriteAppLeftLong].name_or_path,
+                              "!G")) {
+                    launch_games_menu();
+                    consumed = true;
+                    break;
+                } else {
+                    desktop_scene_main_start_favorite(
+                        desktop, &desktop->settings.favorite_apps[FavoriteAppLeftShort]);
+                }
+            }
             consumed = true;
             break;
         case DesktopMainEventOpenFavoriteRightShort:
             DESKTOP_SETTINGS_LOAD(&desktop->settings);
-            desktop_scene_main_start_favorite(
-                desktop, &desktop->settings.favorite_apps[FavoriteAppRightShort]);
+            if(!desktop_scene_main_check_none(
+                   desktop->settings.favorite_apps[FavoriteAppRightShort].name_or_path)) {
+                if(!strcmp(
+                       desktop->settings.favorite_apps[FavoriteAppRightShort].name_or_path,
+                       "!L")) {
+                    scene_manager_set_scene_state(desktop->scene_manager, DesktopSceneLockMenu, 0);
+                    desktop_lock(desktop);
+                    consumed = true;
+                    break;
+                } else if(!strcmp(
+                              desktop->settings.favorite_apps[FavoriteAppRightShort].name_or_path,
+                              "!G")) {
+                    launch_games_menu();
+                    consumed = true;
+                    break;
+                } else {
+                    desktop_scene_main_start_favorite(
+                        desktop, &desktop->settings.favorite_apps[FavoriteAppRightShort]);
+                }
+            }
             consumed = true;
             break;
         case DesktopMainEventOpenFavoriteRightLong:
             DESKTOP_SETTINGS_LOAD(&desktop->settings);
-            desktop_scene_main_start_favorite(
-                desktop, &desktop->settings.favorite_apps[FavoriteAppRightLong]);
+            if(!desktop_scene_main_check_none(
+                   desktop->settings.favorite_apps[FavoriteAppRightLong].name_or_path)) {
+                if(!strcmp(
+                       desktop->settings.favorite_apps[FavoriteAppRightLong].name_or_path, "!L")) {
+                    scene_manager_set_scene_state(desktop->scene_manager, DesktopSceneLockMenu, 0);
+                    desktop_lock(desktop);
+                    consumed = true;
+                    break;
+                } else if(!strcmp(
+                              desktop->settings.favorite_apps[FavoriteAppRightLong].name_or_path,
+                              "!G")) {
+                    launch_games_menu();
+                    consumed = true;
+                    break;
+                } else {
+                    desktop_scene_main_start_favorite(
+                        desktop, &desktop->settings.favorite_apps[FavoriteAppRightLong]);
+                }
+            }
             consumed = true;
             break;
         case DesktopMainEventOpenFavoriteUpLong:
             DESKTOP_SETTINGS_LOAD(&desktop->settings);
             if(!desktop_scene_main_check_none(
                    desktop->settings.favorite_apps[FavoriteAppUpLong].name_or_path)) {
-                desktop_scene_main_start_favorite(
-                desktop, &desktop->settings.favorite_apps[FavoriteAppUpLong]);    
+                if(!strcmp(desktop->settings.favorite_apps[FavoriteAppUpLong].name_or_path, "!L")) {
+                    scene_manager_set_scene_state(desktop->scene_manager, DesktopSceneLockMenu, 0);
+                    desktop_lock(desktop);
+                    consumed = true;
+                    break;
+                } else if(!strcmp(
+                              desktop->settings.favorite_apps[FavoriteAppUpLong].name_or_path,
+                              "!G")) {
+                    launch_games_menu();
+                    consumed = true;
+                    break;
+                } else {
+                    desktop_scene_main_start_favorite(
+                        desktop, &desktop->settings.favorite_apps[FavoriteAppUpLong]);
+                }
             } else {
                 scene_manager_set_scene_state(desktop->scene_manager, DesktopSceneLockMenu, 0);
                 desktop_lock(desktop);
+                consumed = true;
+                break;
             }
             consumed = true;
             break;
@@ -280,42 +387,158 @@ bool desktop_scene_main_on_event(void* context, SceneManagerEvent event) {
             break;
         }
         case DesktopDummyEventOpenLeft:
-            desktop_scene_main_open_fav_or_profile(
-                desktop, &desktop->settings.dummy_apps[DummyAppLeft]);
+            if(!desktop_scene_main_check_none(
+                   desktop->settings.dummy_apps[DummyAppLeft].name_or_path)) {
+                if(!strcmp(desktop->settings.dummy_apps[DummyAppLeft].name_or_path, "!L")) {
+                    scene_manager_set_scene_state(desktop->scene_manager, DesktopSceneLockMenu, 0);
+                    desktop_lock(desktop);
+                    consumed = true;
+                    break;
+                } else if(!strcmp(desktop->settings.dummy_apps[DummyAppLeft].name_or_path, "!G")) {
+                    launch_games_menu();
+                    consumed = true;
+                    break;
+                } else {
+                    desktop_scene_main_open_fav_or_profile(
+                        desktop, &desktop->settings.dummy_apps[DummyAppLeft]);
+                }
+            }
             break;
         case DesktopDummyEventOpenDown:
-            desktop_scene_main_open_fav_or_profile(
-                desktop, &desktop->settings.dummy_apps[DummyAppDown]);
+            if(!desktop_scene_main_check_none(
+                   desktop->settings.dummy_apps[DummyAppDown].name_or_path)) {
+                if(!strcmp(desktop->settings.dummy_apps[DummyAppDown].name_or_path, "!L")) {
+                    scene_manager_set_scene_state(desktop->scene_manager, DesktopSceneLockMenu, 0);
+                    desktop_lock(desktop);
+                    consumed = true;
+                    break;
+                } else if(!strcmp(desktop->settings.dummy_apps[DummyAppDown].name_or_path, "!G")) {
+                    launch_games_menu();
+                    consumed = true;
+                    break;
+                } else {
+                    desktop_scene_main_open_fav_or_profile(
+                        desktop, &desktop->settings.dummy_apps[DummyAppDown]);
+                }
+            }
             break;
         case DesktopDummyEventOpenOk:
-            desktop_scene_main_open_fav_or_profile(
-                desktop, &desktop->settings.dummy_apps[DummyAppOk]);
+            if(!desktop_scene_main_check_none(
+                   desktop->settings.dummy_apps[DummyAppOk].name_or_path)) {
+                if(!strcmp(desktop->settings.dummy_apps[DummyAppOk].name_or_path, "!L")) {
+                    scene_manager_set_scene_state(desktop->scene_manager, DesktopSceneLockMenu, 0);
+                    desktop_lock(desktop);
+                    consumed = true;
+                    break;
+                } else if(!strcmp(desktop->settings.dummy_apps[DummyAppOk].name_or_path, "!G")) {
+                    launch_games_menu();
+                    consumed = true;
+                    break;
+                } else {
+                    desktop_scene_main_open_fav_or_profile(
+                        desktop, &desktop->settings.dummy_apps[DummyAppOk]);
+                }
+            }
             break;
         case DesktopDummyEventOpenUpLong:
             if(!desktop_scene_main_check_none(
                    desktop->settings.dummy_apps[DummyAppUpLong].name_or_path)) {
-                desktop_scene_main_open_fav_or_profile(
-                    desktop, &desktop->settings.dummy_apps[DummyAppUpLong]);
+                if(!strcmp(desktop->settings.dummy_apps[DummyAppUpLong].name_or_path, "!L")) {
+                    scene_manager_set_scene_state(desktop->scene_manager, DesktopSceneLockMenu, 0);
+                    desktop_lock(desktop);
+                    consumed = true;
+                    break;
+                } else if(!strcmp(
+                              desktop->settings.dummy_apps[DummyAppUpLong].name_or_path, "!G")) {
+                    launch_games_menu();
+                    consumed = true;
+                    break;
+                } else {
+                    desktop_scene_main_open_fav_or_profile(
+                        desktop, &desktop->settings.dummy_apps[DummyAppUpLong]);
+                }
             } else {
                 scene_manager_set_scene_state(desktop->scene_manager, DesktopSceneLockMenu, 0);
                 desktop_lock(desktop);
             }
             break;
         case DesktopDummyEventOpenDownLong:
-            desktop_scene_main_open_fav_or_profile(
-                desktop, &desktop->settings.dummy_apps[DummyAppDownLong]);
+            if(!desktop_scene_main_check_none(
+                   desktop->settings.dummy_apps[DummyAppDownLong].name_or_path)) {
+                if(!strcmp(desktop->settings.dummy_apps[DummyAppDownLong].name_or_path, "!L")) {
+                    scene_manager_set_scene_state(desktop->scene_manager, DesktopSceneLockMenu, 0);
+                    desktop_lock(desktop);
+                    consumed = true;
+                    break;
+                } else if(!strcmp(
+                              desktop->settings.dummy_apps[DummyAppDownLong].name_or_path, "!G")) {
+                    launch_games_menu();
+                    consumed = true;
+                    break;
+                } else {
+                    desktop_scene_main_open_fav_or_profile(
+                        desktop, &desktop->settings.dummy_apps[DummyAppDownLong]);
+                }
+            }
             break;
         case DesktopDummyEventOpenLeftLong:
-            desktop_scene_main_open_fav_or_profile(
-                desktop, &desktop->settings.dummy_apps[DummyAppLeftLong]);
+            if(!desktop_scene_main_check_none(
+                   desktop->settings.dummy_apps[DummyAppLeftLong].name_or_path)) {
+                if(!strcmp(desktop->settings.dummy_apps[DummyAppLeftLong].name_or_path, "!L")) {
+                    scene_manager_set_scene_state(desktop->scene_manager, DesktopSceneLockMenu, 0);
+                    desktop_lock(desktop);
+                    consumed = true;
+                    break;
+                } else if(!strcmp(
+                              desktop->settings.dummy_apps[DummyAppLeftLong].name_or_path, "!G")) {
+                    launch_games_menu();
+                    consumed = true;
+                    break;
+                } else {
+                    desktop_scene_main_open_fav_or_profile(
+                        desktop, &desktop->settings.dummy_apps[DummyAppLeftLong]);
+                }
+            }
             break;
         case DesktopDummyEventOpenRightLong:
-            desktop_scene_main_open_fav_or_profile(
-                desktop, &desktop->settings.dummy_apps[DummyAppRightLong]);
+            if(!desktop_scene_main_check_none(
+                   desktop->settings.dummy_apps[DummyAppRightLong].name_or_path)) {
+                if(!strcmp(desktop->settings.dummy_apps[DummyAppRightLong].name_or_path, "!L")) {
+                    scene_manager_set_scene_state(desktop->scene_manager, DesktopSceneLockMenu, 0);
+                    desktop_lock(desktop);
+                    consumed = true;
+                    break;
+                } else if(!strcmp(
+                              desktop->settings.dummy_apps[DummyAppRightLong].name_or_path,
+                              "!G")) {
+                    launch_games_menu();
+                    consumed = true;
+                    break;
+                } else {
+                    desktop_scene_main_open_fav_or_profile(
+                        desktop, &desktop->settings.dummy_apps[DummyAppRightLong]);
+                }
+            }
+
             break;
         case DesktopDummyEventOpenOkLong:
-            desktop_scene_main_open_fav_or_profile(
-                desktop, &desktop->settings.dummy_apps[DummyAppOkLong]);
+            if(!desktop_scene_main_check_none(
+                   desktop->settings.dummy_apps[DummyAppOkLong].name_or_path)) {
+                if(!strcmp(desktop->settings.dummy_apps[DummyAppOkLong].name_or_path, "!L")) {
+                    scene_manager_set_scene_state(desktop->scene_manager, DesktopSceneLockMenu, 0);
+                    desktop_lock(desktop);
+                    consumed = true;
+                    break;
+                } else if(!strcmp(
+                              desktop->settings.dummy_apps[DummyAppOkLong].name_or_path, "!G")) {
+                    launch_games_menu();
+                    consumed = true;
+                    break;
+                } else {
+                    desktop_scene_main_open_fav_or_profile(
+                        desktop, &desktop->settings.dummy_apps[DummyAppOkLong]);
+                }
+            }
             break;
 
         case DesktopLockedEventUpdate:

--- a/applications/services/desktop/views/desktop_view_main.c
+++ b/applications/services/desktop/views/desktop_view_main.c
@@ -102,7 +102,7 @@ bool desktop_main_input_callback(InputEvent* event, void* context) {
             if(event->key == InputKeyOk) {
                 main_view->callback(DesktopAnimationEventNewIdleAnimation, main_view->context);
             } else if(event->key == InputKeyUp) {
-                main_view->callback(DesktopMainEventLock, main_view->context); // Lock Flipper
+                main_view->callback(DesktopMainEventOpenDOOM, main_view->context); // OPENS DOOM
             } else if(event->key == InputKeyDown) {
                 main_view->callback(
                     DesktopMainEventOpenZombiez, main_view->context); // OPENS Zombiez

--- a/applications/services/desktop/views/desktop_view_main.c
+++ b/applications/services/desktop/views/desktop_view_main.c
@@ -102,7 +102,7 @@ bool desktop_main_input_callback(InputEvent* event, void* context) {
             if(event->key == InputKeyOk) {
                 main_view->callback(DesktopAnimationEventNewIdleAnimation, main_view->context);
             } else if(event->key == InputKeyUp) {
-                main_view->callback(DesktopMainEventOpenDOOM, main_view->context); // OPENS DOOM
+                main_view->callback(DesktopMainEventLock, main_view->context); // Lock Flipper
             } else if(event->key == InputKeyDown) {
                 main_view->callback(
                     DesktopMainEventOpenZombiez, main_view->context); // OPENS Zombiez

--- a/applications/settings/desktop_settings/scenes/desktop_settings_scene_favorite.c
+++ b/applications/settings/desktop_settings/scenes/desktop_settings_scene_favorite.c
@@ -16,10 +16,14 @@
 #define NONE_APPLICATION_NAME  "None (disable)"
 #define LOCK_APPLICATION_NAME  "Lock Flipper"
 
-#define EXTERNAL_APPLICATION_INDEX (2)
+#define LOCK_FLIPPER_INDEX (2)
+#define GAMES_MENU_INDEX   (3)
+#define GAMES_MENU_NAME    "Game menu"
+
+#define EXTERNAL_APPLICATION_INDEX (4)
 #define EXTERNAL_APPLICATION_NAME  ("[Select App]")
 
-#define MAIN_LIST_APPLICATION_OFFSET (3)
+#define MAIN_LIST_APPLICATION_OFFSET (5)
 
 #define PRESELECTED_SPECIAL 0xffffffff
 
@@ -71,7 +75,7 @@ void desktop_settings_scene_favorite_on_enter(void* context) {
     FavoriteApp* curr_favorite_app = NULL;
     bool is_dummy_app = false;
     bool default_passport = false;
-    bool lock_if_none = true;
+    bool lock_if_none = false;
 
     if((favorite_id & SCENE_STATE_SET_DUMMY_APP) == 0) {
         furi_assert(favorite_id < FavoriteAppNumber);
@@ -104,6 +108,20 @@ void desktop_settings_scene_favorite_on_enter(void* context) {
         submenu,
         lock_if_none ? (LOCK_APPLICATION_NAME) : (NONE_APPLICATION_NAME),
         NONE_APPLICATION_INDEX,
+        desktop_settings_scene_favorite_submenu_callback,
+        app);
+
+    submenu_add_item(
+        submenu,
+        LOCK_APPLICATION_NAME,
+        LOCK_FLIPPER_INDEX,
+        desktop_settings_scene_favorite_submenu_callback,
+        app);
+
+    submenu_add_item(
+        submenu,
+        GAMES_MENU_NAME,
+        GAMES_MENU_INDEX,
         desktop_settings_scene_favorite_submenu_callback,
         app);
 
@@ -140,6 +158,14 @@ void desktop_settings_scene_favorite_on_enter(void* context) {
             (curr_favorite_app->name_or_path[1] == '\0') &&
             (curr_favorite_app->name_or_path[0] == '?')) {
             pre_select_item = NONE_APPLICATION_INDEX;
+        } else if(
+            (curr_favorite_app->name_or_path[1] == 'L') &&
+            (curr_favorite_app->name_or_path[0] == '!')) {
+            pre_select_item = LOCK_FLIPPER_INDEX;
+        } else if(
+            (curr_favorite_app->name_or_path[1] == 'G') &&
+            (curr_favorite_app->name_or_path[0] == '!')) {
+            pre_select_item = GAMES_MENU_INDEX;
         } else {
             pre_select_item = EXTERNAL_APPLICATION_INDEX;
         }
@@ -175,6 +201,16 @@ bool desktop_settings_scene_favorite_on_event(void* context, SceneManagerEvent e
         } else if(event.event == NONE_APPLICATION_INDEX) {
             curr_favorite_app->name_or_path[0] = '?';
             curr_favorite_app->name_or_path[1] = '\0';
+            consumed = true;
+        } else if(event.event == LOCK_FLIPPER_INDEX) {
+            curr_favorite_app->name_or_path[0] = '!';
+            curr_favorite_app->name_or_path[1] = 'L';
+            curr_favorite_app->name_or_path[2] = '\0';
+            consumed = true;
+        } else if(event.event == GAMES_MENU_INDEX) {
+            curr_favorite_app->name_or_path[0] = '!';
+            curr_favorite_app->name_or_path[1] = 'G';
+            curr_favorite_app->name_or_path[2] = '\0';
             consumed = true;
         } else if(event.event == EXTERNAL_APPLICATION_INDEX) {
             const DialogsFileBrowserOptions browser_options = {


### PR DESCRIPTION
# What's new

- Added options to lock Flipper or launch game menu to favourites.
- Hold up long in game only mode to lock Flipper

# Verification 

- Settings->Desktop->Favorite - 
- You can choose now Lock Flipper or Game menu, works with any button in standard mode/dummy mode
- Hold up long in game only mode to lock Flipper

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
