### PR TITLE
SubGHz: hold up long to lock keyboard in read mode.

### DIFF
--- a/applications/main/subghz/views/receiver.c
+++ b/applications/main/subghz/views/receiver.c
@@ -537,6 +537,9 @@ bool subghz_view_receiver_input(InputEvent* event, void* context) {
     } else if(event->key == InputKeyLeft && event->type == InputTypeShort) {
         subghz_receiver->callback(SubGhzCustomEventViewReceiverConfig, subghz_receiver->context);
         consumed = true;
+    } else if(event->key == InputKeyUp && event->type == InputTypeLong) {
+        subghz_view_receiver_set_lock(subghz_receiver,true);
+        consumed = true;
     } else if(event->key == InputKeyRight && event->type == InputTypeLong) {
         with_view_model(
             subghz_receiver->view,


### PR DESCRIPTION
# What's new

- SubGHz: hold up long to lock keyboard in read mode.

# Verification 

- SubGHz->Read
- Hold long UP button - keys are locked now.

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
