### PR TITLE
Update mcp_can_2515.h

### DIFF
--- a/applications/external/canbus/libraries/mcp_can_2515.h
+++ b/applications/external/canbus/libraries/mcp_can_2515.h
@@ -1,7 +1,7 @@
 #ifndef __MCP_CAN_2515_H_
 #define __MCP_CAN_2515_H_
 
-#include "Spi_lib.h"
+#include "spi_lib.h"
 #include "log_user.h"
 
 #ifdef __LOG_USER_H_


### PR DESCRIPTION
capitalization causes build error on linux
