### PR TITLE
Update GAMES_ONLY.md

### DIFF
--- a/GAMES_ONLY.md
+++ b/GAMES_ONLY.md
@@ -8,7 +8,7 @@
 
 # KEY MAPS FOR GAMES ONLY MODE 
 <pre>
-Long  OK:    Clock
+Long  LEFT:  Clock
 Short UP:    Game Menu
 </pre>
 


### PR DESCRIPTION
Fix wrong key map for open clock screen

# What's new

- I just fix the name of the button to open the "clock" screen in game mode.

# Verification 

- Try to open "clock" screen in game mode with previous and current button name

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
