### PR TITLE
Formatted LaCrosse Bv2 & Bv3 names shorter

### DIFF
--- a/applications/external/weather_station/protocols/lacrosse_tx141bv3.h
+++ b/applications/external/weather_station/protocols/lacrosse_tx141bv3.h
@@ -8,7 +8,7 @@
 #include "ws_generic.h"
 #include <lib/subghz/blocks/math.h>
 
-#define WS_PROTOCOL_LACROSSE_TX141BV3_NAME "LaCrosse_TX141Bv3"
+#define WS_PROTOCOL_LACROSSE_TX141BV3_NAME "LC_TX141Bv3"
 
 typedef struct WSProtocolDecoderLaCrosse_TX141BV3 WSProtocolDecoderLaCrosse_TX141BV3;
 typedef struct WSProtocolEncoderLaCrosse_TX141BV3 WSProtocolEncoderLaCrosse_TX141BV3;

--- a/applications/external/weather_station/protocols/lacrosse_tx141thbv2.h
+++ b/applications/external/weather_station/protocols/lacrosse_tx141thbv2.h
@@ -8,7 +8,7 @@
 #include "ws_generic.h"
 #include <lib/subghz/blocks/math.h>
 
-#define WS_PROTOCOL_LACROSSE_TX141THBV2_NAME "LaCrosse_TX141THBv2"
+#define WS_PROTOCOL_LACROSSE_TX141THBV2_NAME "LC_TX141THBv2"
 
 typedef struct WSProtocolDecoderLaCrosse_TX141THBv2 WSProtocolDecoderLaCrosse_TX141THBv2;
 typedef struct WSProtocolEncoderLaCrosse_TX141THBv2 WSProtocolEncoderLaCrosse_TX141THBv2;


### PR DESCRIPTION
# What's new

The names onscreen were too long (LaCrosse_TX141THBv2 and v3) and were shorttned to LC_TX141THBv2 and LC_TX141THBv3. Before this it made some text truncate.

# Verification 

- Read a new Lacrosse v2 or v3 tag.  That's how i saw it was too long (someone in the neighborhood has one)

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
