### PR TITLE
ADD: Ventra parsing plugin to Metroflip.  Updated: NFC ventra_parser.fal.

### DIFF
--- a/applications/external/metroflip/README.md
+++ b/applications/external/metroflip/README.md
@@ -77,6 +77,7 @@ This is a list of metro cards and transit systems that need support or have part
 | **Metromoney**     | 🇬🇪 Tbilisi, Georgia                          | MIFARE Classic    |
 | **myki**           | 🇦🇺 Melbourne (and surrounds), VIC, Australia | MIFARE DESFire    |
 | **Navigo**         | 🇫🇷 Paris, France                             | Calypso           |
+| **nol**            | 🇦🇪 Dubai, UAE                                | MIFARE DESFire    |
 | **Opal**           | 🇦🇺 Sydney (and surrounds), NSW, Australia    | MIFARE DESFire    |
 | **Opus**           | 🇨🇦 Montreal, QC, Canada                      | Calypso           |
 | **Rav-Kav**        | 🇮🇱 Israel                                    | Calypso           |
@@ -86,7 +87,7 @@ This is a list of metro cards and transit systems that need support or have part
 | **Troika**         | 🇷🇺 Moscow, Russia                            | MIFARE Classic    |
 | **Trt**            | 🇨🇳 Tianjin, China                            | MIFARE Ultralight |
 | **Octopus**        | 🇭🇰 Hong Kong                                 | FeliCa            |
-| **nol**            | 🇦🇪 Dubai, UAE                                | MIFARE DESFire    |
+| **Ventra**         | 🇺🇸 Chicago, IL, USA                          | MIFARE Ultralight |
 
 
 
@@ -112,6 +113,7 @@ This is a list of metro cards and transit systems that need support or have part
 - **TRT Parser:** [@luu176](https://github.com/luu176), [@zinongli](https://github.com/zinongli)
 - **Octopus Parser:** [@zinongli](https://github.com/zinongli)
 - **nol Parser:** [@zinongli](https://github.com/zinongli)
+- **Ventra Parser:** [@hazardousvoltage](https://github.com/hazardousvoltage), [@FatherDivine](https://github.com/FatherDivine)
 
 ---
 

--- a/applications/external/metroflip/application.fam
+++ b/applications/external/metroflip/application.fam
@@ -206,3 +206,12 @@ App(
     sources=["scenes/plugins/trt.c"],
     fal_embedded=True,
 )
+
+App(
+    appid="ventra_plugin",
+    apptype=FlipperAppType.PLUGIN,
+    entry_point="ventra_plugin_ep",
+    requires=["metroflip"],
+    sources=["scenes/plugins/ventra.c"],
+    fal_embedded=True,
+)

--- a/applications/external/metroflip/files/ventra/stations/bus/stations.txt
+++ b/applications/external/metroflip/files/ventra/stations/bus/stations.txt
@@ -1,0 +1,11 @@
+# Chicago Transit Authority (CTA) - Bus Stops
+# Format: cubic_id,stop_name
+#
+# CTA refers to Bus service as "B" (Bus) in its system.
+# IDs are stored as decimal Cubic stop IDs (the Ventra system's internal ID format).
+# Example prefix: 16959 (decimal numeric)
+#
+# Data source: Ventra card dumps and CTA stop database
+# https://data.cityofchicago.org/Transportation/CTA-Bus-Stops-kml/84eu-buny/about_data
+
+16959,Milwaukee & Laramie (CTA 5436)

--- a/applications/external/metroflip/files/ventra/stations/train/stations.txt
+++ b/applications/external/metroflip/files/ventra/stations/train/stations.txt
@@ -1,0 +1,12 @@
+# Chicago Transit Authority (CTA) - Rail Stations (The "L" System)
+# Format: cubic_id,station_name
+#
+# CTA refers to Rail (Train) service as "T" (Train) in its system.
+# This is specifically the CTA's "L" elevated/subway rapid transit system.
+# IDs are stored as 4-digit uppercase hexadecimal Cubic station IDs.
+# Example prefix: 003B, 003E (hex format)
+#
+# Data source: Ventra card dumps and CTA station database
+
+003B,Jefferson Park Transit Cntr (CTA 41280)
+003E,O'Hare (South-bnd to Forest Prk) (CTA 40890)

--- a/applications/external/metroflip/scenes/metroflip_scene_auto.c
+++ b/applications/external/metroflip/scenes/metroflip_scene_auto.c
@@ -10,8 +10,74 @@
 #include "desfire.h"
 #include <nfc/protocols/mf_desfire/mf_desfire_poller.h>
 #include <lib/nfc/protocols/mf_desfire/mf_desfire.h>
+#include <nfc/protocols/mf_ultralight/mf_ultralight_poller.h>
 #include "../api/metroflip/metroflip_api.h"
 #define TAG "Metroflip:Scene:Auto"
+
+// Detection constants for Ventra
+#define VENTRA_MIN_PAGES_REQUIRED 7 // Need pages 0-6
+
+// Detection constants for TRT (Tianjin Railway Transit)
+#define TRT_MIN_PAGES_REQUIRED        15 // Need pages 0-14 (0x0E)
+#define TRT_LATEST_SALE_MARKER        0x02
+#define TRT_SALE_RECORD_TIME_STAMP_A  0x0C
+#define TRT_SALE_RECORD_TIME_STAMP_B  0x0E
+#define TRT_FULL_SALE_TIME_STAMP_PAGE 0x09
+
+// Helper function to determine if MfUltralight card is Ventra
+static bool is_ventra_card(const MfUltralightData* data) {
+    // Ventra detection requires pages 4 and 6
+    if(data->pages_read < VENTRA_MIN_PAGES_REQUIRED) return false;
+
+    // Ventra detection signature from ventra.c
+    return (data->page[4].data[0] == 0x0A && data->page[4].data[1] == 4 &&
+            data->page[4].data[2] == 0 && data->page[6].data[0] == 0 &&
+            data->page[6].data[1] == 0 && data->page[6].data[2] == 0);
+}
+
+// Helper function to determine if MfUltralight card is TRT
+static bool is_trt_card(const MfUltralightData* data) {
+    // TRT detection requires pages up to 0x0E (14)
+    if(data->pages_read < TRT_MIN_PAGES_REQUIRED) return false;
+
+    // TRT detection logic from trt.c
+    uint8_t latest_sale_page = 0;
+
+    if(data->page[TRT_SALE_RECORD_TIME_STAMP_A].data[0] == TRT_LATEST_SALE_MARKER) {
+        latest_sale_page = TRT_SALE_RECORD_TIME_STAMP_A;
+    } else if(data->page[TRT_SALE_RECORD_TIME_STAMP_B].data[0] == TRT_LATEST_SALE_MARKER) {
+        latest_sale_page = TRT_SALE_RECORD_TIME_STAMP_B;
+    } else {
+        return false;
+    }
+
+    // Check if the sale record was backed up
+    // Note: latest_sale_page is guaranteed to be either 0x0C (12) or 0x0E (14) here,
+    // so latest_sale_page - 1 will be 11 or 13, safely within bounds
+    const uint8_t* partial_record_pointer = &data->page[latest_sale_page - 1].data[0];
+    const uint8_t* full_record_pointer = &data->page[TRT_FULL_SALE_TIME_STAMP_PAGE].data[0];
+    uint32_t latest_sale_record = bit_lib_get_bits_32(partial_record_pointer, 3, 20);
+    uint32_t latest_sale_full_record = bit_lib_get_bits_32(full_record_pointer, 0, 27);
+
+    if(latest_sale_record != (latest_sale_full_record & 0xFFFFF)) return false;
+    if((latest_sale_record == 0) || (latest_sale_full_record == 0)) return false;
+
+    return true;
+}
+
+// Determine card type for MfUltralight cards
+static const char* determine_mf_ultralight_type(const MfUltralightData* data) {
+    if(is_ventra_card(data)) {
+        FURI_LOG_I(TAG, "Detected: Ventra");
+        return "ventra";
+    }
+    if(is_trt_card(data)) {
+        FURI_LOG_I(TAG, "Detected: TRT");
+        return "trt";
+    }
+    FURI_LOG_I(TAG, "Unknown MfUltralight card");
+    return "Unknown Card";
+}
 
 static NfcCommand
     metroflip_scene_detect_desfire_poller_callback(NfcGenericEvent event, void* context) {
@@ -33,6 +99,34 @@ static NfcCommand
     } else if(mf_desfire_event->type == MfDesfirePollerEventTypeReadFailed) {
         view_dispatcher_send_custom_event(app->view_dispatcher, MetroflipCustomEventPollerSuccess);
         command = NfcCommandContinue;
+    }
+
+    return command;
+}
+
+static NfcCommand
+    metroflip_scene_detect_mf_ultralight_poller_callback(NfcGenericEvent event, void* context) {
+    furi_assert(event.protocol == NfcProtocolMfUltralight);
+
+    Metroflip* app = context;
+    NfcCommand command = NfcCommandContinue;
+
+    const MfUltralightPollerEvent* mf_ultralight_event = event.event_data;
+    if(mf_ultralight_event->type == MfUltralightPollerEventTypeReadSuccess) {
+        nfc_device_set_data(
+            app->nfc_device, NfcProtocolMfUltralight, nfc_poller_get_data(app->poller));
+        const MfUltralightData* data =
+            nfc_device_get_data(app->nfc_device, NfcProtocolMfUltralight);
+        furi_string_reset(app->text_box_store);
+        app->card_type = determine_mf_ultralight_type(data);
+        view_dispatcher_send_custom_event(app->view_dispatcher, MetroflipCustomEventPollerSuccess);
+
+        command = NfcCommandStop;
+    } else if(mf_ultralight_event->type == MfUltralightPollerEventTypeReadFailed) {
+        // If read failed, still try to proceed with unknown type
+        app->card_type = "Unknown Card";
+        view_dispatcher_send_custom_event(app->view_dispatcher, MetroflipCustomEventPollerSuccess);
+        command = NfcCommandStop;
     }
 
     return command;
@@ -228,9 +322,10 @@ bool metroflip_scene_auto_on_event(void* context, SceneManagerEvent event) {
                 nfc_detected_protocols_get_protocol(app->detected_protocols, 0) ==
                 NfcProtocolMfUltralight) {
                 FURI_LOG_I(TAG, "Protocol is MfUl");
-                app->card_type = "trt"; // place holder for now
                 app->is_desfire = false;
-                scene_manager_next_scene(app->scene_manager, MetroflipSceneParse);
+                app->poller = nfc_poller_alloc(app->nfc, NfcProtocolMfUltralight);
+                nfc_poller_start(
+                    app->poller, metroflip_scene_detect_mf_ultralight_poller_callback, app);
                 consumed = true;
             } else if(
                 nfc_detected_protocols_get_protocol(app->detected_protocols, 0) ==

--- a/applications/external/metroflip/scenes/metroflip_scene_credits.c
+++ b/applications/external/metroflip/scenes/metroflip_scene_credits.c
@@ -36,6 +36,7 @@ void metroflip_scene_credits_on_enter(void* context) {
     furi_string_cat_printf(str, "TRT Parser:\nluu176, zinongli");
     furi_string_cat_printf(str, "Octopus Parser:\nzinongli\n\n");
     furi_string_cat_printf(str, "nol Parser:\nzinongli\n\n");
+    furi_string_cat_printf(str, "Ventra Parser:\nhazardousvoltage, FatherDivine\n\n");
 
     widget_add_text_scroll_element(widget, 0, 0, 128, 64, furi_string_get_cstr(str));
 

--- a/applications/external/metroflip/scenes/metroflip_scene_supported.c
+++ b/applications/external/metroflip/scenes/metroflip_scene_supported.c
@@ -34,6 +34,7 @@ void metroflip_scene_supported_on_enter(void* context) {
     furi_string_cat_printf(str, " - Troika:\nMoscow, Russia\nProtocol: MIFARE Classic\n\n");
     furi_string_cat_printf(str, " - TRT:\nTianjin, China\nProtocol: MIFARE Ultralight\n\n");
     furi_string_cat_printf(str, " - Suica:\nJapan\nProtocol: FeliCa\n\n");
+    furi_string_cat_printf(str, " - Ventra:\nChicago, IL, USA\nProtocol: MIFARE Ultralight\n\n");
 
     widget_add_text_scroll_element(widget, 0, 0, 128, 64, furi_string_get_cstr(str));
 

--- a/applications/external/metroflip/scenes/plugins/trt.c
+++ b/applications/external/metroflip/scenes/plugins/trt.c
@@ -1,6 +1,9 @@
-// Flipper Zero parser for for Tianjin Railway Transit (TRT)
+// Flipper Zero parser for Tianjin Railway Transit (TRT)
 // https://en.wikipedia.org/wiki/Tianjin_Metro
 // Reverse engineering and parser development by @Torron (Github: @zinongli) and added to Metroflip by @Lupin (Github: @luu176)
+// Additional improvements by FatherDivine:
+//   - Added auto_mode support to use already-read data from auto-detect scan
+//   - Added trailing newline to parsed output to prevent text obscured by buttons
 
 #include <flipper_application.h>
 #include "../../metroflip_i.h"
@@ -102,9 +105,12 @@ static NfcCommand trt_poller_callback(NfcGenericEvent event, void* context) {
         view_dispatcher_send_custom_event(app->view_dispatcher, event);
         return NfcCommandStop;
     } else if(mf_ultralight_event->type == MfUltralightPollerEventTypeAuthRequest) {
-        view_dispatcher_send_custom_event(app->view_dispatcher, MetroflipCustomEventPollerFail);
+        // Don't treat auth request as failure - let the read continue
+        // The read may still succeed even if auth fails
+        return NfcCommandContinue;
     } else if(mf_ultralight_event->type == MfUltralightPollerEventTypeAuthSuccess) {
-        view_dispatcher_send_custom_event(app->view_dispatcher, MetroflipCustomEventPollerSuccess);
+        // Auth success is informational, continue with read
+        return NfcCommandContinue;
     }
 
     return NfcCommandContinue;
@@ -114,6 +120,7 @@ static void trt_on_enter(Metroflip* app) {
     dolphin_deed(DolphinDeedNfcRead);
 
     if(app->data_loaded) {
+        // Data loaded from file
         FURI_LOG_I(TAG, "TRT loaded");
         Storage* storage = furi_record_open(RECORD_STORAGE);
         FlipperFormat* ff = flipper_format_file_alloc(storage);
@@ -141,7 +148,40 @@ static void trt_on_enter(Metroflip* app) {
             view_dispatcher_switch_to_view(app->view_dispatcher, MetroflipViewWidget);
         }
         flipper_format_free(ff);
+        furi_record_close(RECORD_STORAGE);
+    } else if(app->auto_mode) {
+        // Coming from Auto scene - data already read into app->nfc_device
+        FURI_LOG_I(TAG, "TRT using data from auto-detect scan");
+        const MfUltralightData* ultralight_data =
+            nfc_device_get_data(app->nfc_device, NfcProtocolMfUltralight);
+        
+        // Safety check for null data
+        if(!ultralight_data) {
+            FURI_LOG_E(TAG, "Failed to get ultralight data from nfc_device");
+            view_dispatcher_send_custom_event(app->view_dispatcher, MetroflipCustomEventPollerFail);
+            return;
+        }
+        
+        FuriString* parsed_data = furi_string_alloc();
+        Widget* widget = app->widget;
+
+        furi_string_reset(app->text_box_store);
+        if(!trt_parse(parsed_data, ultralight_data)) {
+            furi_string_reset(app->text_box_store);
+            FURI_LOG_I(TAG, "Unknown card type");
+            furi_string_printf(parsed_data, "\e#Unknown card\n");
+        }
+        widget_add_text_scroll_element(
+            widget, 0, 0, 128, 64, furi_string_get_cstr(parsed_data));
+        widget_add_button_element(
+            widget, GuiButtonTypeLeft, "Exit", metroflip_exit_widget_callback, app);
+        widget_add_button_element(
+            widget, GuiButtonTypeRight, "Save", metroflip_save_widget_callback, app);
+
+        furi_string_free(parsed_data);
+        view_dispatcher_switch_to_view(app->view_dispatcher, MetroflipViewWidget);
     } else {
+        // Manual scan - need to read card
         FURI_LOG_I(TAG, "TRT not loaded");
         // Setup view
         Popup* popup = app->popup;
@@ -228,7 +268,8 @@ static bool trt_on_event(Metroflip* app, SceneManagerEvent event) {
 static void trt_on_exit(Metroflip* app) {
     widget_reset(app->widget);
 
-    if(app->poller && !app->data_loaded) {
+    // Only stop poller if we started one (manual scan, not auto_mode or file load)
+    if(app->poller && !app->data_loaded && !app->auto_mode) {
         nfc_poller_stop(app->poller);
         nfc_poller_free(app->poller);
     }

--- a/applications/external/metroflip/scenes/plugins/ventra.c
+++ b/applications/external/metroflip/scenes/plugins/ventra.c
@@ -173,7 +173,7 @@ static bool ventra_search_file(const char* file_path, const char* id_str, char* 
         if(*trimmed == '\0') continue;
 
         // Skip comment lines
-        if(line[0] == '#') continue;
+        if(*trimmed == '#') continue;
 
         char* comma = strchr(line, ',');
         if(!comma) continue;

--- a/applications/external/metroflip/scenes/plugins/ventra.c
+++ b/applications/external/metroflip/scenes/plugins/ventra.c
@@ -1,4 +1,4 @@
-// Parser for CTA Ventra Ultralight cards
+// Parser for CTA Ventra Ultralight cards - Metroflip Plugin Version
 // Made by @hazardousvoltage
 // Based on my own research, with...
 // Credit to https://www.lenrek.net/experiments/compass-tickets/ & MetroDroid project for underlying info
@@ -10,22 +10,15 @@
 //   - Removed unused dt_diff function
 //   - Fixed unnecessary storage_file_close on failed file open
 //   - Added two-tiered station lookup (bus/train specific files with CSV fallback)
+//   - Added auto_mode support to use already-read data from auto-detect scan
 //   - Added trailing newline to parsed output to prevent text obscured by buttons
 //
 // This parser can decode the paper single-use and single/multi-day paper passes using Ultralight EV1
 // The plastic cards are DESFire and fully locked down, not much useful info extractable
-// TODO:
-// - Sort the duplicate/rare ticket types
-// - (WIP) Database of stop IDs for trains, buses. There's just too damn many, but you can find them here:
-//   https://data.cityofchicago.org/Transportation/CTA-Bus-Stops-kml/84eu-buny/about_data
-//   Currently the database is cta_stops.csv in /ext/apps_data/ventra/cta_stops.csv (see below).
-//   Seems Ventra uses it's own "Cubic ID" in it's backend and matches w/ CTA's stop IDs.
-//   If true, will need to gather from Ventra or manually get enough tags/stops on a tag to decipher.
-//   For manual adding to the CSV, you have to just know where the stop was when it was scanned and lookup on google maps.
-// - Speedup the csv process so it doesn't take so long to check the entire list. But may remove the list for now given CTA stop IDs != what's read on Ventra passes.
-// - Generalize to handle all known Cubic Nextfare Ultralight systems?  Anyone wants to send me specimen dumps, hit me up on Discord.
+//
+// Adapted for Metroflip plugin API
 
-/* 
+/*
  * STOP DATABASE FORMAT (IMPORTANT)
  *
  * This parser supports lookup for BOTH bus and train stops using a two-tiered system.
@@ -51,19 +44,22 @@
  *   - Fall back to cta_stops.csv if not found
  */
 
-#include "nfc_supported_card_plugin.h"
+#include <flipper_application.h>
+#include "../../metroflip_i.h"
+#include "../../metroflip_plugins.h"
+#include "../../api/metroflip/metroflip_api.h"
 
-#include <flipper_application/flipper_application.h>
 #include <nfc/protocols/mf_ultralight/mf_ultralight.h>
-#include "datetime.h"
-#include <furi_hal.h>
+#include <nfc/protocols/mf_ultralight/mf_ultralight_poller.h>
 
-// Added for stop database lookup
+#include <dolphin/dolphin.h>
+#include <datetime.h>
+#include <furi_hal.h>
 #include <storage/storage.h>
 #include <stdio.h>
 #include <string.h>
 
-#define TAG "Ventra"
+#define TAG "Metroflip:Scene:Ventra"
 
 // Paths to station database files on SD card
 // Primary paths - separate files for bus and train (Metroflip app)
@@ -72,15 +68,18 @@
 // Fallback path - unified CSV (for users without Metroflip)
 #define VENTRA_STOP_DB_PATH        "/ext/apps_data/ventra/cta_stops.csv"
 
-DateTime ventra_exp_date = {0}, ventra_validity_date = {0};
-uint8_t ventra_high_seq = 0, ventra_cur_blk = 0, ventra_mins_active = 0;
+static DateTime ventra_exp_date = {0};
+static DateTime ventra_validity_date = {0};
+static uint8_t ventra_high_seq = 0;
+static uint8_t ventra_cur_blk = 0;
+static uint8_t ventra_mins_active = 0;
 
-uint32_t time_now() {
+static uint32_t ventra_time_now(void) {
     return furi_hal_rtc_get_timestamp();
 }
 
-static DateTime dt_delta(DateTime dt, uint8_t delta_days) {
-    // returns shifted DateTime, from initial DateTime and time offset in seconds
+static DateTime ventra_dt_delta(DateTime dt, uint8_t delta_days) {
+    // returns shifted DateTime, from initial DateTime and time offset in days
     DateTime dt_shifted = {0};
     datetime_timestamp_to_datetime(
         datetime_datetime_to_timestamp(&dt) - (uint64_t)delta_days * 86400, &dt_shifted);
@@ -92,11 +91,10 @@ static DateTime dt_delta(DateTime dt, uint8_t delta_days) {
 // - Soft expiration date passed:
 //   - For passes, n days after first use
 //   - For tickets, 2 hours after first use
-//   Calculating these is dumber than it needs to be, see xact record parser.
-bool isExpired(void) {
+static bool ventra_is_expired(void) {
     uint32_t ts_hard_exp = datetime_datetime_to_timestamp(&ventra_exp_date);
     uint32_t ts_soft_exp = datetime_datetime_to_timestamp(&ventra_validity_date);
-    uint32_t ts_now = time_now();
+    uint32_t ts_now = ventra_time_now();
     return (ts_now >= ts_hard_exp || ts_now > ts_soft_exp);
 }
 
@@ -271,14 +269,11 @@ static FuriString* ventra_parse_xact(const MfUltralightData* data, uint8_t blk, 
     uint8_t line = data->page[blk + 2].data[3];
 
     // This computes the block timestamp, based on the card expiration date and delta from it
-    DateTime dt = dt_delta(ventra_exp_date, day);
+    DateTime dt = ventra_dt_delta(ventra_exp_date, day);
     dt.hour = (ts & 0x7FF) / 60;
     dt.minute = (ts & 0x7FF) % 60;
 
-    // If sequence is 0, block isn't used yet (new card with only one active block, typically the first one.
-    // Otherwise, the block with higher sequence is the latest transaction, and the other block is prior transaction.
-    // Not necessarily in that order on the card.  We need the latest data to compute validity and pretty-print them
-    // in reverse chrono.  So this mess sets some globals as to which block is current, computes the validity times, etc.
+    // If sequence is 0, block isn't used yet
     if(seq == 0) {
         furi_string_printf(ventra_xact_str, "-- EMPTY --");
         return (ventra_xact_str);
@@ -287,12 +282,9 @@ static FuriString* ventra_parse_xact(const MfUltralightData* data, uint8_t blk, 
         ventra_high_seq = seq;
         ventra_cur_blk = blk;
         ventra_mins_active = data->page[blk + 1].data[3];
-        // Figure out the soft expiration.  For passes it's easy, the readers update the "exp" field in the transaction record.
-        // Tickets, not so much, readers don't update "exp", but each xact record has "minutes since last tap" which is
-        // updated and carried forward.  That, plus transaction timestamp, gives the expiration time.
-        if(tran_type == 6) { // Furthermore, purchase transactions set bogus expiration dates
+        if(tran_type == 6) {
             if(is_pass) {
-                ventra_validity_date = dt_delta(ventra_exp_date, exp_day);
+                ventra_validity_date = ventra_dt_delta(ventra_exp_date, exp_day);
                 ventra_validity_date.hour = (exp & 0x7FF) / 60;
                 ventra_validity_date.minute = (exp & 0x7FF) % 60;
             } else {
@@ -304,12 +296,7 @@ static FuriString* ventra_parse_xact(const MfUltralightData* data, uint8_t blk, 
     }
 
     // Type 0 = Purchase, 1 = Train ride, 2 = Bus ride
-    // TODO: Check PACE and see if it uses a different line code
     char linemap[3] = "PTB";
-
-    // Original format strings:
-    // For bus (line == 2): "%c %5d %04d-%02d-%02d %02d:%02d"
-    // Else:                "%c %04X %04d-%02d-%02d %02d:%02d"
 
     // Unified bus/train stop lookup
     char stop_name[128];
@@ -323,9 +310,6 @@ static FuriString* ventra_parse_xact(const MfUltralightData* data, uint8_t blk, 
     have_name = ventra_lookup_stop_name_str(id_key, line, stop_name, sizeof(stop_name));
 
     if(have_name) {
-        // Use the CSV name + the exact ID key used for lookup
-        // The (V %s) puts a V for Ventra as we're using Ventra IDs in the dabatase (least first 2 entries for now)
-        // And the other ones in the database csv are actual CTA stops, but Ventra seems to not use those.
         furi_string_printf(
             ventra_xact_str,
             "%c %s (V %s) %04d-%02d-%02d %02d:%02d",
@@ -367,17 +351,21 @@ static FuriString* ventra_parse_xact(const MfUltralightData* data, uint8_t blk, 
     return (ventra_xact_str);
 }
 
-static bool ventra_parse(const NfcDevice* device, FuriString* parsed_data) {
-    furi_assert(device);
+static bool ventra_parse(FuriString* parsed_data, const MfUltralightData* data) {
+    furi_assert(data);
     furi_assert(parsed_data);
-
-    const MfUltralightData* data = nfc_device_get_data(device, NfcProtocolMfUltralight);
 
     bool parsed = false;
 
+    // Reset static state for each parse
+    ventra_exp_date = (DateTime){0};
+    ventra_validity_date = (DateTime){0};
+    ventra_high_seq = 0;
+    ventra_cur_blk = 0;
+    ventra_mins_active = 0;
+
     do {
-        // This test can probably be improved -- it matches every Ventra I've seen, but will also match others
-        // in the same family.  Or maybe we just generalize this parser.
+        // This test can probably be improved -- it matches every Ventra I've seen
         if(data->page[4].data[0] != 0x0A || data->page[4].data[1] != 4 ||
            data->page[4].data[2] != 0 || data->page[6].data[0] != 0 ||
            data->page[6].data[1] != 0 || data->page[6].data[2] != 0) {
@@ -385,18 +373,17 @@ static bool ventra_parse(const NfcDevice* device, FuriString* parsed_data) {
             break;
         }
 
-        // Parse the product record, display interesting data & extract info needed to parse transaction blocks
-        // Had this in its own function, ended up just setting a bunch of shitty globals, so inlined it instead.
+        // Parse the product record
         FuriString* ventra_prod_str = furi_string_alloc();
         uint8_t otp = data->page[3].data[0];
         uint8_t prod_code = data->page[5].data[2];
         bool is_pass = false;
         switch(prod_code) {
         case 2:
-        case 0x1F: // Only ever seen one of these, it parses like a Single
+        case 0x1F:
             furi_string_cat_printf(ventra_prod_str, "Single");
             break;
-        case 0x01: // gleamed from a single-use ticket purchased 12-06-2025 (FatherDivine)
+        case 0x01:
             furi_string_cat_printf(ventra_prod_str, "Single");
             break;
         case 3:
@@ -404,13 +391,12 @@ static bool ventra_parse(const NfcDevice* device, FuriString* parsed_data) {
             is_pass = true;
             furi_string_cat_printf(ventra_prod_str, "1-Day");
             break;
-        case 4: // Last I checked, 3 day passes only available at airport TVMs & social service agencies
+        case 4:
             is_pass = true;
             furi_string_cat_printf(ventra_prod_str, "3-Day");
             break;
         default:
-            is_pass =
-                true; // There are some card types I don't know what they are, but they parse like a pass, not a ticket.
+            is_pass = true;
             furi_string_cat_printf(ventra_prod_str, "0x%02X", data->page[5].data[2]);
             break;
         }
@@ -426,14 +412,14 @@ static bool ventra_parse(const NfcDevice* device, FuriString* parsed_data) {
             ventra_exp_date.day = date_d;
             ventra_exp_date.month = date_m;
             ventra_exp_date.year = date_y;
-            ventra_validity_date = ventra_exp_date; // Until we know otherwise
+            ventra_validity_date = ventra_exp_date;
         } else {
             FURI_LOG_W(TAG, "Invalid month value: %d", date_m);
             furi_string_free(ventra_prod_str);
             break;
         }
 
-        // Parse the transaction blocks.  This sets a few sloppy globals, but it's too complex and repetitive to inline.
+        // Parse the transaction blocks
         FuriString* ventra_xact_str1 = ventra_parse_xact(data, 8, is_pass);
         FuriString* ventra_xact_str2 = ventra_parse_xact(data, 12, is_pass);
 
@@ -443,10 +429,6 @@ static bool ventra_parse(const NfcDevice* device, FuriString* parsed_data) {
         char* card_states[5] = {"???", "NEW", "ACT", "USED", "EXP"};
 
         if(ventra_high_seq > 1) card_state = 2;
-        // On "ticket" product, the OTP bits mark off rides used.  Bit 0 seems to be unused, the next 3 are set as rides are used.
-        // Some, not all, readers will set the high bits to 0x7 when a card is tapped after it's expired or depleted.  Have not
-        // seen other combinations, but if we do, we'll make a nice ???.  1-day passes set the OTP bit 1 on first use.  3-day
-        // passes do not.  But we don't really care, since they don't matter on passes, unless you're trying to rollback one.
         if(!is_pass) {
             switch(otp) {
             case 0:
@@ -471,7 +453,7 @@ static bool ventra_parse(const NfcDevice* device, FuriString* parsed_data) {
                 break;
             }
         }
-        if(isExpired()) {
+        if(ventra_is_expired()) {
             card_state = 4;
             rides_left = 0;
         }
@@ -510,7 +492,7 @@ static bool ventra_parse(const NfcDevice* device, FuriString* parsed_data) {
         furi_string_cat_printf(parsed_data, "Tx count: %d\n", ventra_high_seq);
         furi_string_cat_printf(
             parsed_data,
-            "Hard Expiry: %04d-%02d-%02d",
+            "Hard Expiry: %04d-%02d-%02d\n",
             ventra_exp_date.year,
             ventra_exp_date.month,
             ventra_exp_date.day);
@@ -525,18 +507,211 @@ static bool ventra_parse(const NfcDevice* device, FuriString* parsed_data) {
     return parsed;
 }
 
+static NfcCommand ventra_poller_callback(NfcGenericEvent event, void* context) {
+    furi_assert(event.protocol == NfcProtocolMfUltralight);
+
+    Metroflip* app = context;
+    const MfUltralightPollerEvent* mf_ultralight_event = event.event_data;
+
+    if(mf_ultralight_event->type == MfUltralightPollerEventTypeReadSuccess) {
+        nfc_device_set_data(
+            app->nfc_device, NfcProtocolMfUltralight, nfc_poller_get_data(app->poller));
+
+        const MfUltralightData* data =
+            nfc_device_get_data(app->nfc_device, NfcProtocolMfUltralight);
+        uint32_t custom_event = (data->pages_read == data->pages_total) ?
+                                    MetroflipCustomEventPollerSuccess :
+                                    MetroflipCustomEventPollerFail;
+        view_dispatcher_send_custom_event(app->view_dispatcher, custom_event);
+        return NfcCommandStop;
+    } else if(mf_ultralight_event->type == MfUltralightPollerEventTypeAuthRequest) {
+        // Don't treat auth request as failure - let the read continue
+        // The read may still succeed even if auth fails
+        return NfcCommandContinue;
+    } else if(mf_ultralight_event->type == MfUltralightPollerEventTypeAuthSuccess) {
+        // Auth success is informational, continue with read
+        return NfcCommandContinue;
+    }
+
+    return NfcCommandContinue;
+}
+
+static void ventra_on_enter(Metroflip* app) {
+    dolphin_deed(DolphinDeedNfcRead);
+
+    if(app->data_loaded) {
+        // Data loaded from file
+        FURI_LOG_I(TAG, "Ventra data loaded from file");
+        Storage* storage = furi_record_open(RECORD_STORAGE);
+        FlipperFormat* ff = flipper_format_file_alloc(storage);
+        if(flipper_format_file_open_existing(ff, app->file_path)) {
+            MfUltralightData* ultralight_data = mf_ultralight_alloc();
+            mf_ultralight_load(ultralight_data, ff, 2);
+            FuriString* parsed_data = furi_string_alloc();
+            Widget* widget = app->widget;
+
+            furi_string_reset(app->text_box_store);
+            if(!ventra_parse(parsed_data, ultralight_data)) {
+                furi_string_reset(app->text_box_store);
+                FURI_LOG_I(TAG, "Unknown card type");
+                furi_string_printf(parsed_data, "\e#Unknown card\n");
+            }
+            widget_add_text_scroll_element(
+                widget, 0, 0, 128, 64, furi_string_get_cstr(parsed_data));
+
+            widget_add_button_element(
+                widget, GuiButtonTypeRight, "Exit", metroflip_exit_widget_callback, app);
+            widget_add_button_element(
+                widget, GuiButtonTypeCenter, "Delete", metroflip_delete_widget_callback, app);
+            mf_ultralight_free(ultralight_data);
+            furi_string_free(parsed_data);
+            view_dispatcher_switch_to_view(app->view_dispatcher, MetroflipViewWidget);
+        } else {
+            // Proper cleanup when file open fails (Copilot review feedback)
+            FURI_LOG_E(TAG, "Failed to open file: %s", app->file_path);
+        }
+        flipper_format_free(ff);
+        furi_record_close(RECORD_STORAGE);
+    } else if(app->auto_mode) {
+        // Coming from Auto scene - data already read into app->nfc_device
+        FURI_LOG_I(TAG, "Ventra using data from auto-detect scan");
+        const MfUltralightData* ultralight_data =
+            nfc_device_get_data(app->nfc_device, NfcProtocolMfUltralight);
+        
+        // Safety check for null data
+        if(!ultralight_data) {
+            FURI_LOG_E(TAG, "Failed to get ultralight data from nfc_device");
+            view_dispatcher_send_custom_event(app->view_dispatcher, MetroflipCustomEventPollerFail);
+            return;
+        }
+        
+        FuriString* parsed_data = furi_string_alloc();
+        Widget* widget = app->widget;
+
+        furi_string_reset(app->text_box_store);
+        if(!ventra_parse(parsed_data, ultralight_data)) {
+            furi_string_reset(app->text_box_store);
+            FURI_LOG_I(TAG, "Unknown card type");
+            furi_string_printf(parsed_data, "\e#Unknown card\n");
+        }
+        widget_add_text_scroll_element(
+            widget, 0, 0, 128, 64, furi_string_get_cstr(parsed_data));
+        widget_add_button_element(
+            widget, GuiButtonTypeLeft, "Exit", metroflip_exit_widget_callback, app);
+        widget_add_button_element(
+            widget, GuiButtonTypeRight, "Save", metroflip_save_widget_callback, app);
+
+        furi_string_free(parsed_data);
+        view_dispatcher_switch_to_view(app->view_dispatcher, MetroflipViewWidget);
+    } else {
+        // Manual scan - need to read card
+        FURI_LOG_I(TAG, "Ventra scanning for card");
+        // Setup view
+        Popup* popup = app->popup;
+        popup_set_header(popup, "Apply\n card to\nthe back", 68, 30, AlignLeft, AlignTop);
+        popup_set_icon(popup, 0, 3, &I_RFIDDolphinReceive_97x61);
+
+        // Start worker
+        view_dispatcher_switch_to_view(app->view_dispatcher, MetroflipViewPopup);
+        app->poller = nfc_poller_alloc(app->nfc, NfcProtocolMfUltralight);
+        nfc_poller_start(app->poller, ventra_poller_callback, app);
+
+        metroflip_app_blink_start(app);
+    }
+}
+
+static bool ventra_on_event(Metroflip* app, SceneManagerEvent event) {
+    bool consumed = false;
+
+    if(event.type == SceneManagerEventTypeCustom) {
+        if(event.event == MetroflipCustomEventCardDetected) {
+            Popup* popup = app->popup;
+            popup_set_header(popup, "DON'T\nMOVE", 68, 30, AlignLeft, AlignTop);
+            consumed = true;
+        } else if(event.event == MetroflipCustomEventPollerSuccess) {
+            const MfUltralightData* ultralight_data =
+                nfc_device_get_data(app->nfc_device, NfcProtocolMfUltralight);
+            FuriString* parsed_data = furi_string_alloc();
+            Widget* widget = app->widget;
+
+            furi_string_reset(app->text_box_store);
+            if(!ventra_parse(parsed_data, ultralight_data)) {
+                furi_string_reset(app->text_box_store);
+                FURI_LOG_I(TAG, "Unknown card type");
+                furi_string_printf(parsed_data, "\e#Unknown card\n");
+            }
+            widget_add_text_scroll_element(
+                widget, 0, 0, 128, 64, furi_string_get_cstr(parsed_data));
+            widget_add_button_element(
+                widget, GuiButtonTypeLeft, "Exit", metroflip_exit_widget_callback, app);
+            widget_add_button_element(
+                widget, GuiButtonTypeRight, "Save", metroflip_save_widget_callback, app);
+
+            furi_string_free(parsed_data);
+            view_dispatcher_switch_to_view(app->view_dispatcher, MetroflipViewWidget);
+            metroflip_app_blink_stop(app);
+            consumed = true;
+        } else if(event.event == MetroflipCustomEventCardLost) {
+            Popup* popup = app->popup;
+            popup_set_header(popup, "Card \n lost", 68, 30, AlignLeft, AlignTop);
+            consumed = true;
+        } else if(event.event == MetroflipCustomEventWrongCard) {
+            Popup* popup = app->popup;
+            popup_set_header(popup, "WRONG \n CARD", 68, 30, AlignLeft, AlignTop);
+            consumed = true;
+        } else if(event.event == MetroflipCustomEventPollerFail) {
+            FuriString* parsed_data = furi_string_alloc();
+            Widget* widget = app->widget;
+
+            furi_string_reset(app->text_box_store);
+            FURI_LOG_I(TAG, "Unknown card type");
+            furi_string_printf(parsed_data, "\e#Unknown card\n");
+
+            widget_add_text_scroll_element(
+                widget, 0, 0, 128, 64, furi_string_get_cstr(parsed_data));
+            widget_add_button_element(
+                widget, GuiButtonTypeRight, "Exit", metroflip_exit_widget_callback, app);
+
+            furi_string_free(parsed_data);
+            view_dispatcher_switch_to_view(app->view_dispatcher, MetroflipViewWidget);
+            metroflip_app_blink_stop(app);
+            consumed = true;
+        }
+    } else if(event.type == SceneManagerEventTypeBack) {
+        scene_manager_search_and_switch_to_previous_scene(app->scene_manager, MetroflipSceneStart);
+        consumed = true;
+    }
+
+    return consumed;
+}
+
+static void ventra_on_exit(Metroflip* app) {
+    widget_reset(app->widget);
+
+    // Only stop poller if we started one (manual scan, not auto_mode or file load)
+    if(app->poller && !app->data_loaded && !app->auto_mode) {
+        nfc_poller_stop(app->poller);
+        nfc_poller_free(app->poller);
+    }
+
+    // Clear view
+    popup_reset(app->popup);
+
+    metroflip_app_blink_stop(app);
+}
+
 /* Actual implementation of app<>plugin interface */
-static const NfcSupportedCardsPlugin ventra_plugin = {
-    .protocol = NfcProtocolMfUltralight,
-    .verify = NULL,
-    .read = NULL,
-    .parse = ventra_parse,
+static const MetroflipPlugin ventra_plugin = {
+    .card_name = "Ventra",
+    .plugin_on_enter = ventra_on_enter,
+    .plugin_on_event = ventra_on_event,
+    .plugin_on_exit = ventra_on_exit,
 };
 
 /* Plugin descriptor to comply with basic plugin specification */
 static const FlipperAppPluginDescriptor ventra_plugin_descriptor = {
-    .appid = NFC_SUPPORTED_CARD_PLUGIN_APP_ID,
-    .ep_api_version = NFC_SUPPORTED_CARD_PLUGIN_API_VERSION,
+    .appid = METROFLIP_SUPPORTED_CARD_PLUGIN_APP_ID,
+    .ep_api_version = METROFLIP_SUPPORTED_CARD_PLUGIN_API_VERSION,
     .entry_point = &ventra_plugin,
 };
 

--- a/applications/external/metroflip/scenes/plugins/ventra.c
+++ b/applications/external/metroflip/scenes/plugins/ventra.c
@@ -466,7 +466,7 @@ static bool ventra_parse(FuriString* parsed_data, const MfUltralightData* data) 
 
         furi_string_cat_printf(
             parsed_data,
-            "Exp: %04d-%02d-%02d %02d:%02d",
+            "Exp: %04d-%02d-%02d %02d:%02d\n",
             ventra_validity_date.year,
             ventra_validity_date.month,
             ventra_validity_date.day,

--- a/applications/main/nfc/plugins/supported_cards/ventra.c
+++ b/applications/main/nfc/plugins/supported_cards/ventra.c
@@ -175,7 +175,7 @@ static bool ventra_search_file(const char* file_path, const char* id_str, char* 
         if(*trimmed == '\0') continue;
 
         // Skip comment lines
-        if(line[0] == '#') continue;
+        if(*trimmed == '#') continue;
 
         char* comma = strchr(line, ',');
         if(!comma) continue;


### PR DESCRIPTION
# What's new

- Updated ventra.c for NFC app (creates ventra_parser.fal plugin). Updates include looking for metoflip-style ventra stations.txt files (metroflip/files/ventra/*) with a fallback to cta_stops.csv.
- Added ventra parsing to Metroflip app (built w/ RM FelicaData* API calls instead of Metroflip's FelicaSystem* calls from another FW/API)

Changes to ventra.c (both):
- Added month validation (1-12) to prevent invalid date structures
- Added out_size parameter validation in ventra_lookup_stop_name_str
- Added skip for empty/whitespace-only lines in CSV parsing
- Removed unused dt_diff function
- Fixed unnecessary storage_file_close on failed file open
- Added two-tiered station lookup (bus/train specific files with CSV fallback)
- Added trailing newline to parsed output to prevent text obscured by buttons (in metroflip ventra.c only: NFC app didn't have this issue)
- Added path constants for separate bus/train station files
- Refactored ventra_lookup_stop_name_str() to accept line parameter
- Created ventra_search_file() helper to reduce code duplication
- Both parsers work independently—users with only NFC parser use CSV fallback, users with Metroflip get separate station files.
- Updated documentation in both files
- Added is_ventra_card() - detects Ventra via signature bytes at pages 4 and 6
- Added is_trt_card() - detects TRT via sale marker (0x02) at pages 0x0C/0x0E
- Added determine_mf_ultralight_type() - orchestrates detection (Ventra → TRT → Unknown) *without this, ventra passes would read as unknown*
- Added metroflip_scene_detect_mf_ultralight_poller_callback() - reads card data before type determination (follows existing DESFire pattern)
- Added bounds checking with named constants (VENTRA_MIN_PAGES_REQUIRED, TRT_MIN_PAGES_REQUIRED)
- Among other things

Both ventra.c files now support a two-tiered station lookup system:

Primary lookup (Metroflip station files):
Bus: /ext/apps_assets/metroflip/ventra/stations/bus/stations.txt
Train: /ext/apps_assets/metroflip/ventra/stations/train/stations.txt

Fallback lookup (for users without Metroflip):
/ext/apps_data/ventra/cta_stops.csv

Transport type is determined by line code (1=Train/T, 2=Bus/B). Parser tries type-specific file first, falls back to CSV if not found.


Additions to trt.c:
- Added auto_mode support to use already-read data from auto-detect scan
- Added trailing newline to parsed output to prevent text obscured by buttons


What isn't working: card save function (not sure if that was always broken as I don't have another pass to try). Can still save with native NFC app parser.


# Verification 

- Build firmware/fap and flash/copy to f0 (./fbt fap_ventra_parser for NFC's ventra_parser.fal, ./fbt fap_metroflip for Metroflip which also creates ventra_plugin.fal.
- Open Metroflip → Auto-Detect
- Scan a CTA Ventra Ultralight paper ticket/pass
- Verify card type, expiration, rides left, and transaction history parses correctly
- Bonus: Test with metroflip stations.txt files (metroflip/files/ventra/*) & the CSV stop database at /ext/apps_data/ventra/cta_stops.csv separately to make sure both function.

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
