### PR TITLE
feat(subghz): add silent mode to mute notifications

### DIFF
--- a/applications/main/subghz/scenes/subghz_scene_decode_raw.c
+++ b/applications/main/subghz/scenes/subghz_scene_decode_raw.c
@@ -304,7 +304,11 @@ bool subghz_scene_decode_raw_on_event(void* context, SceneManagerEvent event) {
             notification_message(subghz->notifications, &sequence_blink_cyan_10);
             break;
         case SubGhzNotificationStateRxDone:
-            notification_message(subghz->notifications, &subghz_sequence_rx);
+            if(subghz->last_settings && subghz->last_settings->silent) {
+                notification_message(subghz->notifications, &subghz_sequence_rx_silent);
+            } else {
+                notification_message(subghz->notifications, &subghz_sequence_rx);
+            }
             subghz->state_notifications = SubGhzNotificationStateRx;
             break;
         default:

--- a/applications/main/subghz/scenes/subghz_scene_receiver.c
+++ b/applications/main/subghz/scenes/subghz_scene_receiver.c
@@ -47,6 +47,34 @@ const NotificationSequence subghz_sequence_tx_beep = {
     NULL,
 };
 
+const NotificationSequence subghz_sequence_rx_silent = {
+    &message_green_255,
+
+    &message_display_backlight_on,
+
+    &message_vibro_on,
+    &message_delay_50,
+    &message_vibro_off,
+
+    &message_delay_50,
+    NULL,
+};
+
+const NotificationSequence subghz_sequence_rx_locked_silent = {
+    &message_green_255,
+
+    &message_display_backlight_on,
+
+    &message_vibro_on,
+    &message_delay_50,
+    &message_vibro_off,
+
+    &message_delay_500,
+
+    &message_display_backlight_off,
+    NULL,
+};
+
 static void subghz_scene_receiver_update_statusbar(void* context) {
     SubGhz* subghz = context;
     FuriString* history_stat_str = furi_string_alloc();
@@ -522,10 +550,18 @@ bool subghz_scene_receiver_on_event(void* context, SceneManagerEvent event) {
             }
             break;
         case SubGhzNotificationStateRxDone:
-            if(!subghz_is_locked(subghz)) {
-                notification_message(subghz->notifications, &subghz_sequence_rx);
+            if(subghz->last_settings && subghz->last_settings->silent) {
+                if(!subghz_is_locked(subghz)) {
+                    notification_message(subghz->notifications, &subghz_sequence_rx_silent);
+                } else {
+                    notification_message(subghz->notifications, &subghz_sequence_rx_locked_silent);
+                }
             } else {
-                notification_message(subghz->notifications, &subghz_sequence_rx_locked);
+                if(!subghz_is_locked(subghz)) {
+                    notification_message(subghz->notifications, &subghz_sequence_rx);
+                } else {
+                    notification_message(subghz->notifications, &subghz_sequence_rx_locked);
+                }
             }
             subghz->state_notifications = SubGhzNotificationStateRx;
             break;

--- a/applications/main/subghz/scenes/subghz_scene_receiver_config.c
+++ b/applications/main/subghz/scenes/subghz_scene_receiver_config.c
@@ -301,6 +301,14 @@ static void subghz_scene_receiver_config_set_speaker(VariableItem* item) {
     subghz->last_settings->enable_sound = (speaker_value[index] == SubGhzSpeakerStateEnable);
 }
 
+static void subghz_scene_receiver_config_set_silent(VariableItem* item) {
+    SubGhz* subghz = variable_item_get_context(item);
+    uint8_t index = variable_item_get_current_value_index(item);
+
+    variable_item_set_current_value_text(item, combobox_text[index]);
+    subghz->last_settings->silent = (index == 1);
+}
+
 static void subghz_scene_receiver_config_set_bin_raw(VariableItem* item) {
     SubGhz* subghz = variable_item_get_context(item);
     uint8_t index = variable_item_get_current_value_index(item);
@@ -470,6 +478,7 @@ static void subghz_scene_receiver_config_var_list_enter_callback(void* context, 
 
         subghz_txrx_speaker_set_state(subghz->txrx, speaker_value[default_index]);
         subghz->last_settings->enable_sound = false;
+        subghz->last_settings->silent = false;
 
         subghz_txrx_hopper_set_state(subghz->txrx, hopping_value[default_index]);
         subghz->last_settings->enable_hopping = hopping_value[default_index];
@@ -665,6 +674,17 @@ void subghz_scene_receiver_config_on_enter(void* context) {
         subghz);
     value_index = value_index_uint32(
         subghz_txrx_speaker_get_state(subghz->txrx), speaker_value, COMBO_BOX_COUNT);
+    variable_item_set_current_value_index(item, value_index);
+    variable_item_set_current_value_text(item, combobox_text[value_index]);
+
+    // Silent: disable confirmation tone on successful decode
+    item = variable_item_list_add(
+        subghz->variable_item_list,
+        "Silent",
+        COMBO_BOX_COUNT,
+        subghz_scene_receiver_config_set_silent,
+        subghz);
+    value_index = subghz->last_settings->silent ? 1 : 0;
     variable_item_set_current_value_index(item, value_index);
     variable_item_set_current_value_text(item, combobox_text[value_index]);
 

--- a/applications/main/subghz/subghz_i.h
+++ b/applications/main/subghz/subghz_i.h
@@ -135,3 +135,5 @@ SubGhzRxKeyState subghz_rx_key_state_get(SubGhz* subghz);
 
 extern const NotificationSequence subghz_sequence_rx;
 extern const NotificationSequence subghz_sequence_rx_locked;
+extern const NotificationSequence subghz_sequence_rx_silent;
+extern const NotificationSequence subghz_sequence_rx_locked_silent;

--- a/applications/main/subghz/subghz_last_settings.c
+++ b/applications/main/subghz/subghz_last_settings.c
@@ -22,6 +22,7 @@
 #define SUBGHZ_LAST_SETTING_FIELD_REMOVE_DUPLICATES "RemoveDuplicates"
 #define SUBGHZ_LAST_SETTING_FIELD_REPEATER          "Repeater"
 #define SUBGHZ_LAST_SETTING_FIELD_ENABLE_SOUND      "Sound"
+#define SUBGHZ_LAST_SETTING_FIELD_SILENT            "Silent"
 #define SUBGHZ_LAST_SETTING_FIELD_AUTOSAVE          "Autosave"
 #define SUBGHZ_LAST_SETTING_FIELD_HOPPING_THRESHOLD "HoppingThreshold"
 #define SUBGHZ_LAST_SETTING_FIELD_LED_AND_POWER_AMP "LedAndPowerAmp"
@@ -51,6 +52,7 @@ void subghz_last_settings_load(SubGhzLastSettings* instance, size_t preset_count
     instance->rssi = SUBGHZ_RAW_THRESHOLD_MIN;
     instance->hopping_threshold = -90.0f;
     instance->leds_and_amp = true;
+    instance->silent = false;
 
     Storage* storage = furi_record_open(RECORD_STORAGE);
     FlipperFormat* fff_data_file = flipper_format_file_alloc(storage);
@@ -151,6 +153,13 @@ void subghz_last_settings_load(SubGhzLastSettings* instance, size_t preset_count
                    fff_data_file,
                    SUBGHZ_LAST_SETTING_FIELD_ENABLE_SOUND,
                    &instance->enable_sound,
+                   1)) {
+                flipper_format_rewind(fff_data_file);
+            }
+            if(!flipper_format_read_bool(
+                   fff_data_file,
+                   SUBGHZ_LAST_SETTING_FIELD_SILENT,
+                   &instance->silent,
                    1)) {
                 flipper_format_rewind(fff_data_file);
             }
@@ -279,6 +288,10 @@ bool subghz_last_settings_save(SubGhzLastSettings* instance) {
         }
         if(!flipper_format_write_bool(
                file, SUBGHZ_LAST_SETTING_FIELD_ENABLE_SOUND, &instance->enable_sound, 1)) {
+            break;
+        }
+        if(!flipper_format_write_bool(
+               file, SUBGHZ_LAST_SETTING_FIELD_SILENT, &instance->silent, 1)) {
             break;
         }
         if(!flipper_format_write_bool(

--- a/applications/main/subghz/subghz_last_settings.h
+++ b/applications/main/subghz/subghz_last_settings.h
@@ -29,6 +29,7 @@ typedef struct {
     bool remove_duplicates;
     uint32_t repeater_state;
     bool enable_sound;
+    bool silent;
     bool autosave;
     float hopping_threshold;
     bool leds_and_amp;


### PR DESCRIPTION
# What's new

- New setting in Sub-GHz config to disable the notification sound when a valid signal is detected and decoded, leaving led and vibration unaffected.

# Verification 

- When the "Silent" mode is "ON" and a signal is detected in "Read" mode, the Flipper vibrates and blinks the green led without playing the notification sound from the speaker.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
