### PR TITLE
Fix background setter to use the order list rather than the constant values.

### DIFF
--- a/applications/settings/cfw_app/scenes/cfw_app_scene_interface_passport.c
+++ b/applications/settings/cfw_app/scenes/cfw_app_scene_interface_passport.c
@@ -179,7 +179,7 @@ static void cfw_app_scene_interface_passport_background_changed(VariableItem* it
     uint8_t index = variable_item_get_current_value_index(item);
 
     variable_item_set_current_value_text(item, background_text[index]);
-    app->passport.background = index;
+    app->passport.background = background_value[index];
 }
 
 static void cfw_app_scene_interface_passport_image_changed(VariableItem* item) {


### PR DESCRIPTION
# What's new

- Use the existing order index array in order to set the index properly.

# Verification 

- Change the sort order of the backgrounds in the settings app or add a new background.

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
