### PR TITLE
Make protobuf version generator tolerant when git tags missing

### DIFF
--- a/scripts/fbt_tools/fbt_assets.py
+++ b/scripts/fbt_tools/fbt_assets.py
@@ -168,9 +168,12 @@ def _proto_ver_generator(target, source, env):
         git_describe = describe()
 
     if not git_describe:
-        raise StopError("Failed to process git tags for protobuf versioning")
-
-    git_major, git_minor = git_describe.split(".")
+        # Use a fallback version when git tags are not available
+        print(fg.boldyellow("Using fallback protobuf version"))
+        git_major, git_minor = "0", "4"
+    else:
+        git_major, git_minor = git_describe.split(".")
+    
     version_file_data = (
         "#pragma once",
         f"#define PROTOBUF_MAJOR_VERSION {git_major}",


### PR DESCRIPTION
Why

FBT builds failed with "Failed to process git tags for protobuf versioning" when the protobuf submodule had no reachable tags (shallow or detached checkout). That blocked local builds and CI in some environments.

What this does

- Adds a fallback in scripts/fbt_tools/fbt_assets.py: if git describe --tags fails even after an attempted unshallow fetch, the builder now prints a warning and falls back to a safe protobuf version (0.4). The script still attempts to fetch tags first.

Approach

Instead of failing the build, the protobuf version generator now tries fetch, tries describe, attempts unshallow fetch, and if still unsuccessful writes a small header with default major/minor defines and logs a yellow warning. This preserves the normal behavior when tags are present and avoids hard build errors in shallow checkouts.

Notes and follow-ups

- This is a conservative fallback; ideally the build should fetch tags in CI or ensure submodules are initialized with tags. If maintainers prefer, revert to failing the build and require explicit tag fetching.
- No firmware source code was changed — only the build helper script.

Testing

Built the updater and full firmware locally; artifacts generated under dist/f7-C/ in the session. If reviewers want, can remove the temporary protobuf header generation that was used while iterating.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>